### PR TITLE
Fix: Settings page

### DIFF
--- a/packaging/unraid/root/usr/local/emhttp/plugins/msf/msf.page
+++ b/packaging/unraid/root/usr/local/emhttp/plugins/msf/msf.page
@@ -1,6 +1,6 @@
-Menu="Settings:45"
+Menu="Utilities"
 Title="MSF Free"
-Icon="network-wired"
+Icon="icon-network"
 ---
 <?php
 $cfgPath = "/boot/config/plugins/msf/msf.cfg";


### PR DESCRIPTION
<img width="947" height="863" alt="image" src="https://github.com/user-attachments/assets/36d1d4f8-c553-4fb1-909c-d8ba311ca828" />

This plugin is not compliant with standard Unraid UI design - It's placing its configuration directly upon the Settings tab instead of an icon which then goes to it's settings.

This PR rectifies that.