### PR TITLE
feat: add macOS TUN-only app and Darwin runtime for v0.4.0

### DIFF
--- a/.github/workflows/macos-menu-bar.yml
+++ b/.github/workflows/macos-menu-bar.yml
@@ -1,0 +1,72 @@
+name: macOS menu bar app
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "macos/MSFMenuBar/**"
+      - "cmd/msf/**"
+      - "internal/**"
+      - "web/**"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - ".github/workflows/macos-menu-bar.yml"
+  push:
+    branches:
+      - "main"
+    paths:
+      - "macos/MSFMenuBar/**"
+      - "cmd/msf/**"
+      - "internal/**"
+      - "web/**"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - ".github/workflows/macos-menu-bar.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Run Go tests
+        run: go test ./...
+
+      - name: Run Swift package tests
+        run: make macos-app-test XCODE_DEVELOPER_DIR="$(xcode-select -p)"
+
+      - name: Build unsigned Debug and Release apps
+        run: make macos-app-build-debug macos-app-build-release XCODE_DEVELOPER_DIR="$(xcode-select -p)"
+
+      - name: Verify Debug app bundle
+        run: make macos-app-verify MACOS_CONFIGURATION=Debug XCODE_DEVELOPER_DIR="$(xcode-select -p)"
+
+      - name: Verify Release app bundle
+        run: make macos-app-verify MACOS_CONFIGURATION=Release XCODE_DEVELOPER_DIR="$(xcode-select -p)"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: MSF-macOS-unsigned
+          path: |
+            macos/MSFMenuBar/DerivedData/Build/Products/Debug/MSF.app
+            macos/MSFMenuBar/DerivedData/Build/Products/Release/MSF.app
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,18 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
+  source:
     runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.source.outputs.commit }}
+      version: ${{ steps.source.outputs.version }}
+      tag: ${{ steps.source.outputs.tag }}
+      build_time: ${{ steps.source.outputs.build_time }}
     steps:
       - name: Checkout exact tag
         uses: actions/checkout@v4
@@ -36,21 +45,33 @@ jobs:
             exit 1
           }
           version="${GITHUB_REF_NAME#v}"
+          build_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           {
             echo "commit=$commit"
             echo "version=$version"
+            echo "tag=${GITHUB_REF_NAME}"
+            echo "build_time=$build_time"
           } >> "$GITHUB_OUTPUT"
+
+  linux-assets:
+    needs: source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version-file: go.mod
           cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: 24
           cache: npm
           cache-dependency-path: web/package-lock.json
 
@@ -65,8 +86,12 @@ jobs:
           go test ./...
           npm --prefix web run check
 
-      - name: Build and verify all release assets
-        run: make release-assets VERSION=${{ steps.source.outputs.version }} RELEASE_TAG=${GITHUB_REF_NAME}
+      - name: Build and verify Linux, Unraid, and fnOS assets
+        run: |
+          make release-assets \
+            VERSION=${{ needs.source.outputs.version }} \
+            RELEASE_TAG=${{ needs.source.outputs.tag }} \
+            BUILD_TIME=${{ needs.source.outputs.build_time }}
 
       - name: Prepare TUN smoke-test host
         shell: bash
@@ -83,7 +108,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version="${{ steps.source.outputs.version }}"
+          version="${{ needs.source.outputs.version }}"
           tmp="$(mktemp -d)"
           trap 'rm -rf "$tmp"' EXIT
           mkdir -p "$tmp/unraid" "$tmp/fnos-x86" "$tmp/fnos-arm" "$tmp/fnos-x86-app" "$tmp/fnos-arm-app"
@@ -103,15 +128,159 @@ jobs:
             sudo -E unshare --net -- scripts/smoke-factory-reset.sh "$binary"
           done
 
+      - name: Upload Linux, Unraid, and fnOS assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-linux-assets
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            dist/msf-linux-amd64.tar.gz
+            dist/msf-linux-amd64.tar.gz.sha256
+            dist/msm-free-linux-amd64.tar.gz
+            dist/msm-free-linux-amd64.tar.gz.sha256
+            dist/msf-linux-arm64.tar.gz
+            dist/msf-linux-arm64.tar.gz.sha256
+            dist/msm-free-linux-arm64.tar.gz
+            dist/msm-free-linux-arm64.tar.gz.sha256
+            dist/unraid/msf-${{ needs.source.outputs.version }}-x86_64-1.txz
+            dist/unraid/msf-${{ needs.source.outputs.version }}-x86_64-1.txz.sha256
+            dist/unraid/msf.plg
+            dist/unraid/msf.plg.sha256
+            dist/msf_${{ needs.source.outputs.version }}_x86.fpk
+            dist/msf_${{ needs.source.outputs.version }}_x86.fpk.sha256
+            dist/msf_${{ needs.source.outputs.version }}_arm.fpk
+            dist/msf_${{ needs.source.outputs.version }}_arm.fpk.sha256
+
+  macos-assets:
+    needs: source
+    runs-on: macos-15
+    env:
+      MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+      APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+    steps:
+      - name: Checkout exact tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Test macOS source
+        run: |
+          go test ./...
+          npm --prefix web ci
+          npm --prefix web run check
+          make macos-app-test XCODE_DEVELOPER_DIR="$(xcode-select -p)"
+
+      - name: Import Developer ID and configure notarization
+        id: signing
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in MACOS_CERTIFICATE_P12 MACOS_CERTIFICATE_PASSWORD APPLE_TEAM_ID APPLE_API_KEY_ID APPLE_API_ISSUER_ID APPLE_API_PRIVATE_KEY; do
+            test -n "${!name}" || { echo "Missing required secret: $name" >&2; exit 1; }
+          done
+          certificate_path="$RUNNER_TEMP/developer-id.p12"
+          api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          keychain_path="$RUNNER_TEMP/msf-signing.keychain-db"
+          keychain_password="$(uuidgen)"
+          notary_profile="msf-release"
+          printf '%s' "$MACOS_CERTIFICATE_P12" | /usr/bin/base64 -D > "$certificate_path"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$api_key_path"
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security import "$certificate_path" -k "$keychain_path" -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          security default-keychain -d user -s "$keychain_path"
+          identity="$(security find-identity -v -p codesigning "$keychain_path" | awk '/Developer ID Application/ {print $2; exit}')"
+          test -n "$identity" || { echo "Developer ID Application identity not found" >&2; exit 1; }
+          xcrun notarytool store-credentials "$notary_profile" \
+            --key "$api_key_path" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID"
+          {
+            echo "identity=$identity"
+            echo "notary_profile=$notary_profile"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build, sign, notarize, and package macOS assets
+        run: |
+          make macos-release-assets \
+            VERSION=${{ needs.source.outputs.version }} \
+            RELEASE_TAG=${{ needs.source.outputs.tag }} \
+            BUILD_TIME=${{ needs.source.outputs.build_time }} \
+            MACOS_BUILD_NUMBER=${GITHUB_RUN_NUMBER} \
+            MACOS_DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            MACOS_SIGNING_IDENTITY="${{ steps.signing.outputs.identity }}" \
+            MACOS_NOTARY_PROFILE="${{ steps.signing.outputs.notary_profile }}" \
+            XCODE_DEVELOPER_DIR="$(xcode-select -p)"
+
+      - name: Upload signed and notarized macOS assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos-assets
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal.dmg
+            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal.dmg.sha256
+            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal.zip
+            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal.zip.sha256
+
+  publish:
+    needs:
+      - source
+      - linux-assets
+      - macos-assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Linux, Unraid, and fnOS assets
+        uses: actions/download-artifact@v4
+        with:
+          name: release-linux-assets
+          path: dist
+
+      - name: Download macOS assets
+        uses: actions/download-artifact@v4
+        with:
+          name: release-macos-assets
+          path: dist/macos
+
       - name: Publish immutable GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          version="${{ steps.source.outputs.version }}"
+          version="${{ needs.source.outputs.version }}"
           notes_file="dist/release-notes.md"
-          awk -v tag="${GITHUB_REF_NAME}" '
+          awk -v tag="${{ needs.source.outputs.tag }}" '
             index($0, "## " tag " - ") == 1 { capture=1 }
             capture && printed && /^## v/ { exit }
             capture { print; printed=1 }
@@ -134,5 +303,31 @@ jobs:
             "dist/msf_${version}_x86.fpk.sha256"
             "dist/msf_${version}_arm.fpk"
             "dist/msf_${version}_arm.fpk.sha256"
+            "dist/macos/MSF-${version}-macos-universal.dmg"
+            "dist/macos/MSF-${version}-macos-universal.dmg.sha256"
+            "dist/macos/MSF-${version}-macos-universal.zip"
+            "dist/macos/MSF-${version}-macos-universal.zip.sha256"
           )
-          gh release create "${GITHUB_REF_NAME}" --verify-tag --title "${GITHUB_REF_NAME}" --notes-file "$notes_file" "${assets[@]}"
+          for asset in "${assets[@]}"; do
+            test -f "$asset" || { echo "Missing release asset: $asset" >&2; exit 1; }
+          done
+          sha256sum -c \
+            dist/msf-linux-amd64.tar.gz.sha256 \
+            dist/msm-free-linux-amd64.tar.gz.sha256 \
+            dist/msf-linux-arm64.tar.gz.sha256 \
+            dist/msm-free-linux-arm64.tar.gz.sha256 \
+            "dist/unraid/msf-${version}-x86_64-1.txz.sha256" \
+            dist/unraid/msf.plg.sha256 \
+            "dist/msf_${version}_x86.fpk.sha256" \
+            "dist/msf_${version}_arm.fpk.sha256"
+          (
+            cd dist/macos
+            sha256sum -c \
+              "MSF-${version}-macos-universal.dmg.sha256" \
+              "MSF-${version}-macos-universal.zip.sha256"
+          )
+          gh release create "${{ needs.source.outputs.tag }}" \
+            --verify-tag \
+            --title "${{ needs.source.outputs.tag }}" \
+            --notes-file "$notes_file" \
+            "${assets[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@ msf_html_export.tar.gz
 msm_html_export.tar.gz
 *.tsbuildinfo
 
+# macOS menu bar app generated files
+macos/MSFMenuBar/.build/
+macos/MSFMenuBar/.swiftpm/
+macos/MSFMenuBar/DerivedData/
+macos/MSFMenuBar/MSFMenuBar.xcodeproj/
+
 # Local tooling artifacts (not part of the project)
 .codex/
 graphify-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,44 @@
 # 更新日志
 
-## Unreleased
+## v0.4.0 - 2026-07-29
 
 ### 中文
 
+#### 说明
+
+- v0.4.0 首次加入 macOS 15–26 菜单栏 App 支持；macOS App 第一版为 Beta，仅提供 TUN 模式，不提供系统代理模式，有问题请及时反馈。
+- 本版本从 `main` 的同一个干净 tag 构建 Linux、Unraid、fnOS、macOS 与 Docker；GitHub Release 增加已签名、公证的 Universal 2 DMG/ZIP 及 SHA-256。
+
+#### 新增
+
+- 新增原生 SwiftUI Universal 2 菜单栏 App，覆盖 Apple Silicon 与 Intel，支持启动、LAN 直连保活停止、重启、完全停止、打开网页管理页和实时上下行速度。
+- 新增 root LaunchDaemon 和统一 Network Runtime API；macOS 启用时保存并恢复网络服务 DNS 与原始 IPv4 转发状态，允许系统动态分配 `utunN`，并验证 DNS、Fake-IP 路由和 IPv4 转发状态。
+- 组件下载增加 Mihomo 官方 Darwin 资产、兼容扩展插件的 mssb MosDNS Darwin 资产、GitHub SHA-256 digest 和 Mach-O 架构校验；Web 初始化与系统设置在 macOS 下强制 TUN 并隐藏 nftables。
+
+#### 修复
+
+- 修复 macOS Keychain 在缺少 Data Protection entitlement 时无法保存 `operate` Token 的问题；管理员密码只用于当前登录，不会保存。
+- 修复 macOS provider 订阅下载更新，以及仪表盘硬件信息、系统资源、实时速率、运行时间、MosDNS/Mihomo 状态与运行统计兼容问题。
+- 修复 MosDNS 可观测性解析把时间戳、端口和规则文件名误算为查询域名的问题。
+
 ### English
+
+#### Notes
+
+- v0.4.0 introduces the macOS 15–26 menu bar app. The first macOS release is Beta, supports TUN only, does not provide system-proxy mode, and users are encouraged to report problems promptly.
+- Linux, Unraid, fnOS, macOS, and Docker are built from the same clean tag on `main`. GitHub Release now includes signed and notarized Universal 2 DMG/ZIP assets with SHA-256 files.
+
+#### Added
+
+- Added a native SwiftUI Universal 2 menu bar app for Apple Silicon and Intel with start, LAN-safe direct stop, restart, full stop, WebUI access, and live upload/download speed.
+- Added a root LaunchDaemon and unified Network Runtime API. macOS activation snapshots and restores network-service DNS and the original IPv4 forwarding value, lets the system allocate `utunN`, and validates DNS, Fake-IP routing, and forwarding readiness.
+- Component downloads now use official Mihomo Darwin assets and mssb MosDNS Darwin builds with the required extension plugins, GitHub SHA-256 digests, and Mach-O architecture validation. Web setup/settings force TUN and hide nftables on macOS.
+
+#### Fixed
+
+- Fixed `operate` Token storage when the Data Protection Keychain entitlement is unavailable. Administrator passwords are only used for the current login and are never stored.
+- Fixed macOS provider updates and dashboard compatibility for hardware, resources, live traffic, uptime, and MosDNS/Mihomo status and runtime statistics.
+- Fixed MosDNS observability parsing that could count timestamps, ports, and rule filenames as queried domains.
 
 ## v0.3.9.5 - 2026-07-20
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build frontend import-web package release-package release-assets checksums verify-release-source verify-release-assets unraid fnos test audit-compliance clean
+.PHONY: dev build frontend import-web package release-package release-assets checksums verify-release-source verify-release-assets unraid fnos test audit-compliance macos-app-project macos-app-test macos-app-build macos-app-build-debug macos-app-build-release macos-app-build-signed macos-app-verify macos-release-assets macos-app-open clean
 
 APP_NAME := msf
 DIST := dist
@@ -11,6 +11,14 @@ GOOS ?= linux
 GOARCH ?= amd64
 BIN := $(DIST)/$(APP_NAME)-$(GOOS)-$(GOARCH)
 PACKAGE_DIR := $(DIST)/$(APP_NAME)-$(VERSION)-$(GOOS)-$(GOARCH)
+MACOS_APP_DIR := macos/MSFMenuBar
+XCODE_DEVELOPER_DIR ?= /Applications/Xcode.app/Contents/Developer
+MACOS_CONFIGURATION ?= Debug
+MACOS_BUILD_NUMBER ?= 1
+MACOS_DEVELOPMENT_TEAM ?=
+MACOS_SIGNING_IDENTITY ?=
+MACOS_NOTARY_PROFILE ?=
+MACOS_RELEASE_DIR ?= $(DIST)/macos
 
 GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null || printf unknown)
 SOURCE_COMMIT ?= $(GIT_COMMIT)
@@ -116,6 +124,76 @@ test:
 
 audit-compliance:
 	scripts/audit-compliance.sh
+
+macos-app-project:
+	cd $(MACOS_APP_DIR) && xcodegen generate
+
+macos-app-test:
+	cd $(MACOS_APP_DIR) && DEVELOPER_DIR=$(XCODE_DEVELOPER_DIR) xcrun swift test
+
+macos-app-build: macos-app-build-debug
+
+macos-app-build-debug: frontend macos-app-project
+	cd $(MACOS_APP_DIR) && DEVELOPER_DIR=$(XCODE_DEVELOPER_DIR) xcodebuild \
+		-project MSFMenuBar.xcodeproj \
+		-scheme MSFMenuBar \
+		-configuration Debug \
+		-derivedDataPath DerivedData \
+		ONLY_ACTIVE_ARCH=NO \
+		CODE_SIGNING_ALLOWED=NO \
+		build
+
+macos-app-build-release: frontend macos-app-project
+	cd $(MACOS_APP_DIR) && DEVELOPER_DIR=$(XCODE_DEVELOPER_DIR) xcodebuild \
+		-project MSFMenuBar.xcodeproj \
+		-scheme MSFMenuBar \
+		-configuration Release \
+		-derivedDataPath DerivedData \
+		ONLY_ACTIVE_ARCH=NO \
+		CODE_SIGNING_ALLOWED=NO \
+		build
+
+macos-app-build-signed: frontend macos-app-project
+	@test "$(VERSION)" != "0.1.0-dev" || { echo "VERSION must be set for a signed macOS build" >&2; exit 1; }
+	@test -n "$(MACOS_DEVELOPMENT_TEAM)" || { echo "MACOS_DEVELOPMENT_TEAM is required" >&2; exit 1; }
+	@test -n "$(MACOS_SIGNING_IDENTITY)" || { echo "MACOS_SIGNING_IDENTITY is required" >&2; exit 1; }
+	cd $(MACOS_APP_DIR) && DEVELOPER_DIR=$(XCODE_DEVELOPER_DIR) xcodebuild \
+		-project MSFMenuBar.xcodeproj \
+		-scheme MSFMenuBar \
+		-configuration Release \
+		-derivedDataPath DerivedData \
+		ONLY_ACTIVE_ARCH=NO \
+		ARCHS="arm64 x86_64" \
+		MARKETING_VERSION="$(VERSION)" \
+		CURRENT_PROJECT_VERSION="$(MACOS_BUILD_NUMBER)" \
+		MSF_VERSION="$(VERSION)" \
+		MSF_BUILD_COMMIT="$(GIT_COMMIT)" \
+		MSF_BUILD_TAG="$(BUILD_TAG)" \
+		MSF_BUILD_TAG_COMMIT="$(TAG_COMMIT)" \
+		MSF_BUILD_SOURCE_COMMIT="$(SOURCE_COMMIT)" \
+		MSF_BUILD_DIRTY="$(BUILD_DIRTY)" \
+		MSF_BUILD_TIME="$(BUILD_TIME)" \
+		CODE_SIGNING_ALLOWED=YES \
+		CODE_SIGNING_REQUIRED=YES \
+		CODE_SIGN_STYLE=Manual \
+		CODE_SIGN_IDENTITY="$(MACOS_SIGNING_IDENTITY)" \
+		DEVELOPMENT_TEAM="$(MACOS_DEVELOPMENT_TEAM)" \
+		CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
+		OTHER_CODE_SIGN_FLAGS="--timestamp" \
+		build
+
+macos-app-verify:
+	cd $(MACOS_APP_DIR) && DEVELOPER_DIR=$(XCODE_DEVELOPER_DIR) Scripts/verify-app.sh $(MACOS_CONFIGURATION)
+
+macos-release-assets: verify-release-source macos-app-build-signed
+	@test -n "$(MACOS_NOTARY_PROFILE)" || { echo "MACOS_NOTARY_PROFILE is required" >&2; exit 1; }
+	cd $(MACOS_APP_DIR) && \
+		MACOS_SIGNING_IDENTITY="$(MACOS_SIGNING_IDENTITY)" \
+		MACOS_NOTARY_PROFILE="$(MACOS_NOTARY_PROFILE)" \
+		Scripts/package-release.sh "$(VERSION)" "$(RELEASE_TAG)" "$(GIT_COMMIT)" "$(abspath $(MACOS_RELEASE_DIR))"
+
+macos-app-open: macos-app-build-debug
+	open $(MACOS_APP_DIR)/DerivedData/Build/Products/Debug/MSF.app
 
 clean:
 	rm -rf $(DIST)

--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@
 
 `msf` is an open-source reimplementation of the MSM-style management experience for the MosDNS + Mihomo workflow. It focuses on self-hosted DNS split routing, transparent proxy management, Mihomo management, and platform-native installs.
 
-Current release: `v0.3.9.5`
+Current release: `v0.4.0`
 
 > **Tip: Cloudflare Redirect is experimental.** The `msf cloudflare-redirect` CLI can rewrite user-selected Cloudflare-protected domains to locally scanned Cloudflare CDN IPv4/IPv6 addresses for direct clients only. Results depend on the msf host's ISP route, Cloudflare Anycast, IPv6 reachability, domain-list quality, and MosDNS config. See [Cloudflare Redirect docs](docs/plugins/cloudflare-redirect.md).
 
@@ -22,6 +22,7 @@ Current release: `v0.3.9.5`
 - Mihomo custom configs, CodeMirror YAML editing, component update checks, automatic downloads, update notices, and configurable upgrade behavior.
 - Local upload installation for MosDNS, Mihomo, and Zashboard when online downloads are difficult.
 - Linux tarball/systemd, fnOS FPK, and Unraid PLG support both nftables and TUN. Docker `host-tun` / `macvlan-tun` is supported and TUN-only.
+- macOS 15–26 has a Beta native Universal 2 menu bar app, a root LaunchDaemon, and a TUN-only runtime. It does not use macOS system-proxy mode.
 - Docker deployments must mount a host data directory to container `/opt/msf`; the default examples use `./msf-data:/opt/msf`.
 
 ## Architecture Diagram
@@ -38,6 +39,7 @@ Current release: `v0.3.9.5`
 | fnOS FPK | Supported | [fnOS FPK install](docs/install/fnos-fpk.md) | fnOS / Feiniu App Center or FPK package manager |
 | Unraid PLG | Stable | [Unraid PLG install](docs/install/unraid-plg.md) | Unraid plugin manager |
 | Docker TUN host/macvlan | Supported (TUN-only) | [Docker TUN deployment](docs/docker.en.md) | Docker / Compose / container manager |
+| macOS 15–26 menu bar app | Beta (TUN-only) | [macOS installation and usage](docs/install/macos.md) | In-app daemon installation, repair, and removal |
 
 `msf update` and `msf uninstall` are only for Linux tarball/systemd installs. fnOS FPK, Unraid PLG, and Docker installs must be updated or removed through their platform manager.
 
@@ -46,20 +48,22 @@ Current release: `v0.3.9.5`
 GitHub Release:
 
 ```text
-https://github.com/scoltzero/msf/releases/tag/v0.3.9.5
+https://github.com/scoltzero/msf/releases/tag/v0.4.0
 ```
 
 | Asset | URL |
 |---|---|
-| Linux x86_64 | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf-linux-amd64.tar.gz` |
-| Linux ARM64 | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf-linux-arm64.tar.gz` |
-| fnOS x86 FPK | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf_0.3.9.5_x86.fpk` |
-| fnOS ARM FPK | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf_0.3.9.5_arm.fpk` |
-| Unraid PLG | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf.plg` |
+| Linux x86_64 | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf-linux-amd64.tar.gz` |
+| Linux ARM64 | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf-linux-arm64.tar.gz` |
+| fnOS x86 FPK | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_x86.fpk` |
+| fnOS ARM FPK | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_arm.fpk` |
+| Unraid PLG | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf.plg` |
+| macOS Universal 2 DMG (Beta) | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal.dmg` |
+| macOS Universal 2 ZIP (Beta) | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal.zip` |
 
 ## Quick Start
 
-1. Pick the install guide for your platform: Linux, fnOS, Unraid, or Docker.
+1. Pick the install guide for your platform: Linux, fnOS, Unraid, Docker, or macOS.
 2. Open the WebUI after installation. The default URL is `http://<server-ip>:7777`.
 3. Complete the setup wizard. Setup writes system settings, generates MosDNS/Mihomo configs, and persists them in the database.
 4. Configure DHCP DNS and FakeIP static routes on your main router so LAN clients can use msf.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 `msf` 是一个面向 MosDNS + Mihomo 工作流的 MSM 风格管理面板重构版。项目目标是提供可自部署、可审计的 DNS 分流、透明代理、Mihomo 管理和多平台安装体验。
 
-当前发布版本：`v0.3.9.5`
+当前发布版本：`v0.4.0`
 
 > **提示：Cloudflare Redirect CLI 插件为测试功能。** 它用于让“不走代理的客户端”访问用户指定的 Cloudflare 盾站时，返回本机网络实测较快的 Cloudflare CDN IPv4/IPv6。该功能依赖本机网络、运营商路由、Cloudflare Anycast、域名名单质量和 MosDNS 当前配置，不保证一定比原解析更快或更稳定。详细用法见 [Cloudflare Redirect 文档](docs/plugins/cloudflare-redirect.md)。
 
@@ -22,6 +22,7 @@
 - 支持 Mihomo 自定义配置、CodeMirror YAML 编辑器、组件更新检查、自动下载、更新通知和升级方式配置。
 - 支持 MosDNS、Mihomo、Zashboard 本地上传安装，网络困难时可用预下载核心离线安装。
 - Linux tarball/systemd、fnOS FPK、Unraid PLG 均支持 nftables 与 TUN；Docker `host-tun` / `macvlan-tun` 正式支持且仅允许 TUN。
+- macOS 15–26 提供 Beta 版原生 Universal 2 菜单栏 App、root LaunchDaemon 和 TUN-only 运行时，不提供系统代理模式。
 - Docker 部署必须把宿主机数据目录映射到容器 `/opt/msf`，默认示例使用 `./msf-data:/opt/msf`。
 
 ## 架构原理图
@@ -38,6 +39,7 @@
 | fnOS FPK | 支持 | [fnOS FPK 安装](docs/install/fnos-fpk.md) | fnOS / 飞牛应用中心或 FPK 包管理器 |
 | Unraid PLG | 稳定支持 | [Unraid PLG 安装](docs/install/unraid-plg.md) | Unraid 插件管理页面 |
 | Docker TUN host/macvlan | 支持（仅 TUN） | [Docker TUN 部署](docs/docker.md) | Docker / Compose / 容器管理器 |
+| macOS 15–26 菜单栏 App | Beta（仅 TUN） | [macOS 安装与使用](docs/install/macos.md) | App 内安装、修复和卸载后台 |
 
 `msf update` 和 `msf uninstall` 只面向 Linux tarball/systemd 安装。fnOS FPK、Unraid PLG、Docker 请通过各自平台管理器更新或卸载，避免绕过包状态。
 
@@ -46,20 +48,22 @@
 GitHub Release：
 
 ```text
-https://github.com/scoltzero/msf/releases/tag/v0.3.9.5
+https://github.com/scoltzero/msf/releases/tag/v0.4.0
 ```
 
 | 资产 | 下载地址 |
 |---|---|
-| Linux x86_64 | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf-linux-amd64.tar.gz` |
-| Linux ARM64 | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf-linux-arm64.tar.gz` |
-| fnOS x86 FPK | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf_0.3.9.5_x86.fpk` |
-| fnOS ARM FPK | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf_0.3.9.5_arm.fpk` |
-| Unraid PLG | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf.plg` |
+| Linux x86_64 | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf-linux-amd64.tar.gz` |
+| Linux ARM64 | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf-linux-arm64.tar.gz` |
+| fnOS x86 FPK | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_x86.fpk` |
+| fnOS ARM FPK | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_arm.fpk` |
+| Unraid PLG | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf.plg` |
+| macOS Universal 2 DMG（Beta） | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal.dmg` |
+| macOS Universal 2 ZIP（Beta） | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal.zip` |
 
 ## 快速开始
 
-1. 按你的运行平台选择安装文档：Linux、fnOS、Unraid 或 Docker。
+1. 按你的运行平台选择安装文档：Linux、fnOS、Unraid、Docker 或 macOS。
 2. 安装后打开 WebUI，默认地址是 `http://<服务器IP>:7777`。
 3. 完成初始化向导。首次初始化会写入系统配置、生成 MosDNS/Mihomo 配置，并保存到数据库。
 4. 在主路由上配置 DHCP DNS 和 FakeIP 静态路由，让局域网客户端流量进入 msf。

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # 发布手册
 
-从 v0.3.9.5 开始，Linux、Unraid、fnOS 和 Docker 必须由同一个干净 tag checkout 构建。不要再从 `fnos-fpk` 分支单独编译，也不要移动 tag、覆盖历史 Release 或使用 `gh release upload --clobber` 替换已发布资产。
+从 v0.4.0 开始，Linux、Unraid、fnOS、macOS 和 Docker 必须由 `main` 上同一个干净 tag checkout 构建。`fnos-fpk`、`codex/docker-runtime` 和 `codex/macosapp` 都不是长期发布分支；不要移动 tag、覆盖历史 Release 或使用 `gh release upload --clobber` 替换已发布资产。
 
 ## 1. 发布前检查
 
@@ -10,68 +10,131 @@ git pull --ff-only
 go test ./...
 npm --prefix web ci
 npm --prefix web run check
+make macos-app-test
+make macos-app-build-debug macos-app-build-release
+make macos-app-verify MACOS_CONFIGURATION=Debug
+make macos-app-verify MACOS_CONFIGURATION=Release
 git status --short
 ```
 
-最后一条必须无输出。发布版本以 `0.3.9.5` 这类不带 `v` 的值传给 Make，tag 使用 `v0.3.9.5`。
+最后一条必须无输出。发布版本以 `0.4.0` 这类不带 `v` 的值传给 Make，tag 使用 `v0.4.0`。
 
-## 2. 创建不可变 tag
+## 2. macOS 发布凭据
+
+macOS 正式资产必须使用 Developer ID Application 签名并完成 Apple 公证。GitHub Actions 需要以下 Secrets：
+
+- `MACOS_CERTIFICATE_P12`：Developer ID Application `.p12` 的 Base64。
+- `MACOS_CERTIFICATE_PASSWORD`：`.p12` 密码。
+- `APPLE_TEAM_ID`：Apple Developer Team ID。
+- `APPLE_API_KEY_ID`：App Store Connect API Key ID。
+- `APPLE_API_ISSUER_ID`：App Store Connect Issuer ID。
+- `APPLE_API_PRIVATE_KEY`：API Key `.p8` 完整内容。
+
+未配置这些凭据时不要创建正式 tag。未签名 App 只能用于本地开发测试，不能上传到正式 Release。
+
+## 3. 创建不可变 tag
+
+在与最终候选构建完全相同的 `main` commit 上执行：
 
 ```bash
-VERSION=0.3.9.5
+VERSION=0.4.0
 git tag -a "v$VERSION" -m "v$VERSION"
 git push origin "v$VERSION"
 ```
 
 tag push 会触发两个工作流：
 
-- `Release assets`：测试并构建 Linux amd64/arm64、Unraid、fnOS x86/arm，核验所有二进制来源，执行 factory reset → TUN 黑盒测试，然后创建 GitHub Release。
-- `Docker GHCR`：先构建本地 amd64 镜像并验证 `host-tun`、`macvlan-tun` 与 Docker nft 拒绝，再推送 amd64/arm64 多架构镜像。
+- `Release assets`：分别构建 Linux/Unraid/fnOS 和签名公证的 macOS 资产，全部成功后一次性创建 GitHub Release。
+- `Docker GHCR`：构建并验证 `host-tun`、`macvlan-tun`，再推送 amd64/arm64 多架构镜像。
 
 两个工作流都会确认：
 
 - checkout 工作区干净；
-- tag commit 等于 `HEAD`；
+- tag commit 等于 `HEAD` 并可从 `origin/main` 到达；
 - 二进制嵌入的 source/tag commit 与 tag 一致；
-- 非 Docker 二进制的 Go build metadata 包含 `vcs.modified=false`；
+- Go build metadata 包含 `vcs.modified=false`；
 - Docker OCI `org.opencontainers.image.revision` 等于同一 commit。
 
-## 3. 本地构建门禁
+macOS 工作流还会确认：
 
-tag 已存在并指向当前干净 `HEAD` 时，可运行：
+- App 与 daemon 都包含 `arm64` 和 `x86_64`；
+- App 与 daemon 都使用 Developer ID Application 和 Hardened Runtime；
+- App、DMG 已通过 Apple Notarization 和 Staple；
+- Gatekeeper、Bundle 版本和 daemon 来源信息验证通过。
+
+## 4. 发布资产
+
+GitHub Release 应包含 20 个资产：
+
+- Linux amd64/arm64 tarball、旧名称兼容副本及 SHA-256：8 个。
+- Unraid `.txz`、`.plg` 及 SHA-256：4 个。
+- fnOS x86/ARM `.fpk` 及 SHA-256：4 个。
+- macOS Universal 2 DMG、ZIP 及 SHA-256：4 个。
+
+macOS 资产名称：
+
+```text
+MSF-0.4.0-macos-universal.dmg
+MSF-0.4.0-macos-universal.dmg.sha256
+MSF-0.4.0-macos-universal.zip
+MSF-0.4.0-macos-universal.zip.sha256
+```
+
+fnOS 构建必须使用真正的 `fnpack`；下载失败会中止，绝不生成伪装成 `.fpk` 的 tar.gz fallback。
+
+## 5. 本地发布构建
+
+tag 已存在并指向当前干净 `HEAD` 时，可构建 Linux、Unraid 和 fnOS：
 
 ```bash
-VERSION=0.3.9.5
+VERSION=0.4.0
 make release-assets VERSION="$VERSION" RELEASE_TAG="v$VERSION"
 ```
 
-该命令会生成并验证：
-
-- `msf-linux-amd64.tar.gz` 与 `.sha256`
-- `msm-free-linux-amd64.tar.gz` 与 `.sha256`（旧客户端兼容副本）
-- `msf-linux-arm64.tar.gz` 与 `.sha256`
-- `msm-free-linux-arm64.tar.gz` 与 `.sha256`
-- `msf-<version>-x86_64-1.txz` 与 `.sha256`
-- `msf.plg` 与 `.sha256`
-- `msf_<version>_x86.fpk` 与 `.sha256`
-- `msf_<version>_arm.fpk` 与 `.sha256`
-
-fnOS 构建必须使用真正的 `fnpack`；下载失败会中止，绝不再生成伪装成 `.fpk` 的 tar.gz fallback。
-
-## 4. 发布后核验
+已在 Keychain 中配置 Developer ID 与 Notary Profile 时，可构建 macOS：
 
 ```bash
-VERSION=0.3.9.5
+VERSION=0.4.0
+make macos-release-assets \
+  VERSION="$VERSION" \
+  RELEASE_TAG="v$VERSION" \
+  MACOS_BUILD_NUMBER=1 \
+  MACOS_DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+  MACOS_SIGNING_IDENTITY="$MACOS_SIGNING_IDENTITY" \
+  MACOS_NOTARY_PROFILE="$MACOS_NOTARY_PROFILE"
+```
+
+## 6. 发布后核验
+
+```bash
+VERSION=0.4.0
 gh release view "v$VERSION" --repo scoltzero/msf --json tagName,targetCommitish,assets
 docker buildx imagetools inspect "ghcr.io/scoltzero/msf:v$VERSION"
 ```
 
-确认 GitHub Release 包含全部安装资产与 SHA-256，GHCR 同时存在 `v<version>` 和 `latest`，且 revision 与 Release tag commit 相同。
+确认 GitHub Release 包含全部 20 个安装资产和 SHA-256，GHCR 同时存在 `v0.4.0` 和 `latest`，且 revision 与 Release tag commit 相同。
+
+下载线上 DMG 后再执行一次：
+
+```bash
+xcrun stapler validate MSF-0.4.0-macos-universal.dmg
+spctl --assess --type open --context context:primary-signature --verbose=2 MSF-0.4.0-macos-universal.dmg
+```
 
 如需更新仓库根目录供 Unraid Community Apps 使用的 `msf.plg`，应直接下载本次 Release 中已经验证过的 `msf.plg`，逐字节替换并单独提交；不要重新打包生成另一个 txz 哈希。
 
-## 5. 失败处理
+## 7. 分支清理
 
-- 任何测试、来源、dirty、摘要或黑盒检查失败，都不要创建/覆盖 Release。
-- 如果 tag 尚未产生公开资产，可以删除远端 tag、修复后创建一个新的正确 tag。
-- 如果 Release 或 GHCR 已经公开，保留其不可变性并发布下一个补丁版本，不覆盖旧资产。
+确认 v0.4.0 Release、DMG/ZIP、fnOS FPK 和 Docker 镜像全部可用后，删除本地与远程的：
+
+- `codex/macosapp`
+- `codex/docker-runtime`
+- `fnos-fpk`
+
+长期只保留 `main`；历史发布由不可变 Git tag 和 GitHub Release 保留。
+
+## 8. 失败处理
+
+- 任何测试、来源、dirty、签名、公证、摘要或黑盒检查失败，都不要创建 GitHub Release。
+- 正式 tag 推送前必须完成候选构建；tag 一旦推送不再移动或覆盖。
+- 如果已推送 tag 的发布流程失败，修复后使用新的补丁版本，不替换旧 tag 或旧资产。

--- a/cmd/msf/docker_run_script_test.go
+++ b/cmd/msf/docker_run_script_test.go
@@ -18,7 +18,7 @@ func TestDockerRunScriptHostTunDryRun(t *testing.T) {
 		"--network host",
 		"--device /dev/net/tun:/dev/net/tun",
 		"-e MSF_DOCKER_NETWORK_MODE=host-tun",
-		"ghcr.io/scoltzero/msf:v0.3.9.5",
+		"ghcr.io/scoltzero/msf:v0.4.0",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("host dry run missing %q:\n%s", want, out)

--- a/docker-compose.macvlan.yml
+++ b/docker-compose.macvlan.yml
@@ -1,6 +1,6 @@
 services:
   msf:
-    image: ${MSF_IMAGE:-ghcr.io/scoltzero/msf:v0.3.9.5}
+    image: ${MSF_IMAGE:-ghcr.io/scoltzero/msf:v0.4.0}
     container_name: ${MSF_CONTAINER_NAME:-msf}
     cap_add:
       - NET_ADMIN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   msf:
-    image: ghcr.io/scoltzero/msf:v0.3.9.5
+    image: ghcr.io/scoltzero/msf:v0.4.0
     container_name: msf
     network_mode: host
     cap_add:

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-IMAGE="${MSF_IMAGE:-ghcr.io/scoltzero/msf:v0.3.9.5}"
+IMAGE="${MSF_IMAGE:-ghcr.io/scoltzero/msf:v0.4.0}"
 NAME="${MSF_CONTAINER_NAME:-msf}"
 DATA_DIR="${MSF_DOCKER_DATA_DIR:-$(pwd)/msf-data}"
 NETWORK_MODE="${MSF_DOCKER_NETWORK_MODE:-host-tun}"

--- a/docker.env.example
+++ b/docker.env.example
@@ -1,5 +1,5 @@
 # Shared image/container settings
-MSF_IMAGE=ghcr.io/scoltzero/msf:v0.3.9.5
+MSF_IMAGE=ghcr.io/scoltzero/msf:v0.4.0
 MSF_CONTAINER_NAME=msf
 MSF_DOCKER_DATA_DIR=./msf-data
 

--- a/docs/docker.en.md
+++ b/docs/docker.en.md
@@ -4,12 +4,12 @@
 
 Docker `host-tun` and `macvlan-tun` are now supported as TUN-only modes. The setup UI hides nftables and the backend rejects nftables requests in Docker.
 
-Current release: `v0.3.9.5`
+Current release: `v0.4.0`
 
 Current Docker image:
 
 ```text
-ghcr.io/scoltzero/msf:v0.3.9.5
+ghcr.io/scoltzero/msf:v0.4.0
 ```
 
 The release workflow publishes both the versioned tag and `latest`; production deployments should still pin an explicit version.
@@ -67,7 +67,7 @@ The repository already provides `docker-compose.yml`. If you need to create the 
 ```yaml
 services:
   msf:
-    image: ghcr.io/scoltzero/msf:v0.3.9.5
+    image: ghcr.io/scoltzero/msf:v0.4.0
     container_name: msf
     network_mode: host
     cap_add:
@@ -95,7 +95,7 @@ docker compose up -d
 
 The default compose file uses:
 
-- Image: `ghcr.io/scoltzero/msf:v0.3.9.5`
+- Image: `ghcr.io/scoltzero/msf:v0.4.0`
 - Network: `host`
 - Data directory: `./msf-data:/opt/msf`
 - WebUI: `http://<host-ip>:7777`
@@ -126,7 +126,7 @@ docker run -d \
   -e MSF_DOCKER_NETWORK_MODE=host-tun \
   -e MSF_DATA_DIR=/opt/msf \
   -v "$PWD/msf-data:/opt/msf" \
-  ghcr.io/scoltzero/msf:v0.3.9.5
+  ghcr.io/scoltzero/msf:v0.4.0
 ```
 
 ## Quick Start: macvlan TUN
@@ -140,7 +140,7 @@ The repository already provides `docker-compose.macvlan.yml`. If you need to cre
 ```yaml
 services:
   msf:
-    image: ${MSF_IMAGE:-ghcr.io/scoltzero/msf:v0.3.9.5}
+    image: ${MSF_IMAGE:-ghcr.io/scoltzero/msf:v0.4.0}
     container_name: ${MSF_CONTAINER_NAME:-msf}
     cap_add:
       - NET_ADMIN
@@ -181,7 +181,7 @@ cp docker.env.example .env
 You can also copy this minimal macvlan compose `.env` example and save it as `.env`:
 
 ```text
-MSF_IMAGE=ghcr.io/scoltzero/msf:v0.3.9.5
+MSF_IMAGE=ghcr.io/scoltzero/msf:v0.4.0
 MSF_CONTAINER_NAME=msf
 MSF_DOCKER_DATA_DIR=./msf-data
 MSF_DOCKER_NETWORK_NAME=msf-macvlan
@@ -218,7 +218,7 @@ The script creates the `msf-macvlan` Docker network if it does not already exist
 The first Docker version supports manual Unraid Dockerman setup only. It does not provide a Community Applications container template.
 
 1. Enable custom networks in Unraid Docker settings, and choose `macvlan` or the custom network implementation recommended for your current system.
-2. Create a new container and set the image to `ghcr.io/scoltzero/msf:v0.3.9.5`.
+2. Create a new container and set the image to `ghcr.io/scoltzero/msf:v0.4.0`.
 3. Set Network Type to a custom LAN network such as `br0`.
 4. Set Fixed IP address to a static IPv4 address outside your DHCP pool, for example `192.168.1.10`.
 5. Add this to Extra Parameters or advanced parameters:
@@ -388,7 +388,7 @@ fi
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `MSF_IMAGE` | `ghcr.io/scoltzero/msf:v0.3.9.5` | Container image |
+| `MSF_IMAGE` | `ghcr.io/scoltzero/msf:v0.4.0` | Container image |
 | `MSF_CONTAINER_NAME` | `msf` | Container name |
 | `MSF_DOCKER_DATA_DIR` | `$PWD/msf-data` | Host data directory |
 | `MSF_DOCKER_NETWORK_MODE` | `host-tun` | `host-tun` or `macvlan-tun` |
@@ -503,7 +503,7 @@ docker compose up -d
 Plain Docker:
 
 ```bash
-docker pull ghcr.io/scoltzero/msf:v0.3.9.5
+docker pull ghcr.io/scoltzero/msf:v0.4.0
 docker stop msf
 docker rm msf
 ./docker-run.sh

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,12 +4,12 @@
 
 Docker `host-tun` 与 `macvlan-tun` 已正式收口为 TUN-only。初始化界面不会提供 nftables，后端也会拒绝 Docker 环境的 nftables 请求。
 
-当前版本：`v0.3.9.5`
+当前版本：`v0.4.0`
 
 当前 Docker 镜像：
 
 ```text
-ghcr.io/scoltzero/msf:v0.3.9.5
+ghcr.io/scoltzero/msf:v0.4.0
 ```
 
 发布流程同时推送版本化 tag 与 `latest`；生产部署仍建议固定使用明确的版本 tag。
@@ -67,7 +67,7 @@ host TUN 使用宿主机 IP 对外提供 WebUI、DNS 和代理服务。
 ```yaml
 services:
   msf:
-    image: ghcr.io/scoltzero/msf:v0.3.9.5
+    image: ghcr.io/scoltzero/msf:v0.4.0
     container_name: msf
     network_mode: host
     cap_add:
@@ -95,7 +95,7 @@ docker compose up -d
 
 默认 compose 文件使用：
 
-- 镜像：`ghcr.io/scoltzero/msf:v0.3.9.5`
+- 镜像：`ghcr.io/scoltzero/msf:v0.4.0`
 - 网络：`host`
 - 数据目录：`./msf-data:/opt/msf`
 - WebUI：`http://<宿主机IP>:7777`
@@ -126,7 +126,7 @@ docker run -d \
   -e MSF_DOCKER_NETWORK_MODE=host-tun \
   -e MSF_DATA_DIR=/opt/msf \
   -v "$PWD/msf-data:/opt/msf" \
-  ghcr.io/scoltzero/msf:v0.3.9.5
+  ghcr.io/scoltzero/msf:v0.4.0
 ```
 
 ## 快速启动：macvlan TUN
@@ -140,7 +140,7 @@ macvlan TUN 给容器分配独立 LAN IPv4。路由器侧 DHCP DNS 和 FakeIP �
 ```yaml
 services:
   msf:
-    image: ${MSF_IMAGE:-ghcr.io/scoltzero/msf:v0.3.9.5}
+    image: ${MSF_IMAGE:-ghcr.io/scoltzero/msf:v0.4.0}
     container_name: ${MSF_CONTAINER_NAME:-msf}
     cap_add:
       - NET_ADMIN
@@ -181,7 +181,7 @@ cp docker.env.example .env
 也可以直接复制下面这个 macvlan compose `.env` 示例保存为 `.env` 后修改：
 
 ```text
-MSF_IMAGE=ghcr.io/scoltzero/msf:v0.3.9.5
+MSF_IMAGE=ghcr.io/scoltzero/msf:v0.4.0
 MSF_CONTAINER_NAME=msf
 MSF_DOCKER_DATA_DIR=./msf-data
 MSF_DOCKER_NETWORK_NAME=msf-macvlan
@@ -218,7 +218,7 @@ MSF_DOCKER_IPV4_ADDRESS=192.168.1.10 \
 首版按 Unraid Dockerman 手工配置支持，不提供 Community Applications 容器模板。
 
 1. 在 Unraid Docker 设置中启用自定义网络，并选择 `macvlan` 或你当前系统推荐的自定义网络实现。
-2. 新建容器，镜像填写 `ghcr.io/scoltzero/msf:v0.3.9.5`。
+2. 新建容器，镜像填写 `ghcr.io/scoltzero/msf:v0.4.0`。
 3. Network Type 选择自定义 LAN 网络，例如 `br0`。
 4. Fixed IP address 填写一个未被 DHCP 分配的静态 IPv4，例如 `192.168.1.10`。
 5. Extra Parameters 或高级参数添加：
@@ -388,7 +388,7 @@ fi
 
 | 变量 | 默认值 | 用途 |
 |---|---|---|
-| `MSF_IMAGE` | `ghcr.io/scoltzero/msf:v0.3.9.5` | 容器镜像 |
+| `MSF_IMAGE` | `ghcr.io/scoltzero/msf:v0.4.0` | 容器镜像 |
 | `MSF_CONTAINER_NAME` | `msf` | 容器名称 |
 | `MSF_DOCKER_DATA_DIR` | `$PWD/msf-data` | 宿主机数据目录 |
 | `MSF_DOCKER_NETWORK_MODE` | `host-tun` | `host-tun` 或 `macvlan-tun` |
@@ -503,7 +503,7 @@ docker compose up -d
 普通 Docker：
 
 ```bash
-docker pull ghcr.io/scoltzero/msf:v0.3.9.5
+docker pull ghcr.io/scoltzero/msf:v0.4.0
 docker stop msf
 docker rm msf
 ./docker-run.sh

--- a/docs/install/fnos-fpk.md
+++ b/docs/install/fnos-fpk.md
@@ -4,20 +4,20 @@
 
 fnOS 版本支持 nftables 与 TUN；选择 TUN 前请确认系统提供 `/dev/net/tun`，应用会以 root 运行并在初始化时执行能力预检。
 
-当前版本：`v0.3.9.5`
+当前版本：`v0.4.0`
 
 ## 下载
 
 Release 页面：
 
 ```text
-https://github.com/scoltzero/msf/releases/tag/v0.3.9.5
+https://github.com/scoltzero/msf/releases/tag/v0.4.0
 ```
 
 | 架构 | FPK 资产 |
 |---|---|
-| x86 / amd64 | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf_0.3.9.5_x86.fpk` |
-| ARM / arm64 | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf_0.3.9.5_arm.fpk` |
+| x86 / amd64 | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_x86.fpk` |
+| ARM / arm64 | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_arm.fpk` |
 
 请按 fnOS 设备 CPU 架构选择对应安装包。发布时也会提供对应 `.sha256` 校验文件。
 

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -4,19 +4,19 @@
 
 初始化向导支持 nftables 与 TUN。选择 TUN 时，宿主机必须以 root 运行并提供可用的 `/dev/net/tun`。
 
-当前版本：`v0.3.9.5`
+当前版本：`v0.4.0`
 
 ## 下载
 
 | 架构 | 下载地址 |
 |---|---|
-| x86_64 / amd64 | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf-linux-amd64.tar.gz` |
-| ARM64 / aarch64 | `https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf-linux-arm64.tar.gz` |
+| x86_64 / amd64 | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf-linux-amd64.tar.gz` |
+| ARM64 / aarch64 | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf-linux-arm64.tar.gz` |
 
 Release 页面：
 
 ```text
-https://github.com/scoltzero/msf/releases/tag/v0.3.9.5
+https://github.com/scoltzero/msf/releases/tag/v0.4.0
 ```
 
 ## 安装
@@ -25,20 +25,20 @@ x86_64 / amd64：
 
 ```bash
 curl -L -o msf-linux-amd64.tar.gz \
-  https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf-linux-amd64.tar.gz
+  https://github.com/scoltzero/msf/releases/download/v0.4.0/msf-linux-amd64.tar.gz
 
 tar -xzf msf-linux-amd64.tar.gz -C /tmp
-sudo /tmp/msf-0.3.9.5-linux-amd64/install.sh
+sudo /tmp/msf-0.4.0-linux-amd64/install.sh
 ```
 
 ARM64 / aarch64：
 
 ```bash
 curl -L -o msf-linux-arm64.tar.gz \
-  https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf-linux-arm64.tar.gz
+  https://github.com/scoltzero/msf/releases/download/v0.4.0/msf-linux-arm64.tar.gz
 
 tar -xzf msf-linux-arm64.tar.gz -C /tmp
-sudo /tmp/msf-0.3.9.5-linux-arm64/install.sh
+sudo /tmp/msf-0.4.0-linux-arm64/install.sh
 ```
 
 安装脚本默认完成这些操作：

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -1,0 +1,99 @@
+# macOS 菜单栏版安装与使用
+
+MSF v0.4.0 首次提供 macOS Beta 版菜单栏 App，最低支持 macOS 15，并按 macOS 15–26 的系统 API 兼容范围构建。App 与内嵌后台均为 Universal 2，覆盖 Apple Silicon (`arm64`) 和 Intel (`x86_64`)。
+
+该版本只提供 TUN，不提供“系统代理”模式。MosDNS 负责 DNS 分流，Mihomo 的 `utun` 接管 Fake-IP 路由；root LaunchDaemon 负责保存/恢复本机 DNS、IPv4 转发状态和后台进程，菜单栏 App 本身不持有 root 权限。
+
+## 下载与安装
+
+从 [v0.4.0 GitHub Release](https://github.com/scoltzero/msf/releases/tag/v0.4.0) 下载：
+
+- `MSF-0.4.0-macos-universal.dmg`：推荐安装包。
+- `MSF-0.4.0-macos-universal.zip`：直接解压版本。
+- 对应的 `.sha256`：用于校验下载文件。
+
+DMG、ZIP 与其中的 `MSF.app` 均使用 Apple Developer ID 签名并完成 Apple 公证。使用 DMG 时，将 `MSF.app` 拖入 `/Applications` 后再打开。
+
+首次打开后进入“连接设置”，点击“安装后台”。Release App 使用 `SMAppService` 注册 root LaunchDaemon；如果 macOS 要求批准后台项目，请前往“系统设置 → 通用 → 登录项与扩展”允许 MSF，然后回到 App 刷新状态。
+
+## 使用边界
+
+- 本机接管：启用后将当前出站网络服务的 DNS 临时切换到 `127.0.0.1`，确认 Fake-IP 路由已进入 `utun`，并保持 Mihomo/MosDNS 运行。
+- DNS 接管在 macOS 上是 TUN 运行条件，初始化页和系统设置不会允许关闭；完整停止时按启动前快照恢复，而不是写死一个公共 DNS。
+- Mihomo 配置不固定 `utun` 编号或设备名，由系统分配当前可用的 `utunN`，运行状态只校验 Fake-IP 路由是否确实进入某个 `utun`。
+- 局域网接管：App 无法修改你的路由器。要让 LAN 客户端进入 MSF，仍需把 DHCP DNS 指向这台 Mac 的固定 LAN IP，并把 Fake-IP 网段（默认 `28.0.0.0/8`）静态路由到该 Mac。
+- “停止”是安全直连：TUN 与 DNS 保活，只把 Mihomo 切到 `direct`，避免路由器仍指向这台 Mac 时导致全网断流。
+- “完全停止”会恢复本机 DNS/IPv4 转发快照并停止 Mihomo、MosDNS；如果路由器仍保留上述 DHCP DNS 或静态路由，LAN 客户端可能断流。
+- 启动 MSF 前应退出 Surge、Clash Verge、其他 TUN/VPN，以及占用本机 `53`、`7777`、`9090` 端口的程序。
+
+## 首次使用
+
+1. 将 `MSF.app` 放入 `/Applications` 并打开。
+2. 进入“连接设置”，点击“安装后台”，按系统提示批准 MSF 后台项目。
+3. 后台状态显示“运行中”后，点击“打开网页管理页”，完成六步初始化；macOS 页面只允许选择 TUN。
+4. 在初始化页下载 Mihomo、与现有配置兼容的 mssb MosDNS 和 Zashboard，填写订阅或手动节点。
+5. 回到“连接设置”，使用管理员账户绑定。密码仅用于这一次登录；App 创建的 `operate` Token 保存在 macOS Keychain。
+6. 先确认本机工作正常，再启动数据面并配置路由器的 DHCP DNS 和 Fake-IP 静态路由。
+
+建议给 Mac 配置 DHCP 静态租约。路由器侧示例（假设 Mac 为 `192.168.1.10`）：
+
+```text
+DHCP DNS: 192.168.1.10
+Static route: 28.0.0.0/8 via 192.168.1.10
+```
+
+如果修改了初始化页的 Fake-IP 网段，路由器静态路由必须使用同一网段。应用 DHCP 修改后，让客户端重新获取租约并清理 DNS 缓存。
+
+## 菜单含义
+
+- `启动`：启动/恢复 MosDNS、Mihomo、TUN、本机 DNS 与 LAN IPv4 转发，Mihomo 使用 `rule` 模式。
+- `停止（LAN 直连保活）`：保留数据面和路由，把 Mihomo 切到 `direct`。
+- `重启`：按当前目标状态重启 MosDNS/Mihomo，并重新检查系统网络接管。
+- `完全停止服务…`：恢复系统网络快照并停止全部数据面。
+- `打开网页管理页`：打开本机 `http://127.0.0.1:7777`。
+- `菜单栏显示速度`：显示 Mihomo 实时上下行速率。
+
+## 验证与排错
+
+```bash
+curl http://127.0.0.1:7777/api/v1/version
+sudo launchctl print system/io.github.scoltzero.msf.daemon
+route -n get 28.0.0.1
+networksetup -getdnsservers "Wi-Fi"
+sysctl net.inet.ip.forwarding
+```
+
+启用后，`route -n get 28.0.0.1` 的 `interface` 应为某个 `utunN`。Release App 的 LaunchDaemon 输出可在 macOS“控制台”中按进程 `io.github.scoltzero.msf.daemon` 或 `msf` 检索。
+
+系统数据位于 `/Library/Application Support/MSF`，网络恢复快照位于 `configs/network/darwin-state.json`。快照会记录原始 DNS 和 `net.inet.ip.forwarding`，恢复时不会假定其初始值一定为 `0`。
+
+## 更新、修复与卸载
+
+更新 App 时，先退出 MSF，将新版 `MSF.app` 替换到 `/Applications`，重新打开后在“连接设置”中执行后台修复，使 LaunchDaemon 使用新版内嵌后台。
+
+卸载前优先执行“完全停止服务…”，然后到“连接设置”点击“卸载后台”。后台和 LaunchDaemon 注册会被移除，`/Library/Application Support/MSF` 用户数据默认保留；确认不再需要时再手工清理该目录。
+
+## 源码构建
+
+要求：
+
+- 完整 Xcode 16 或更高版本；已验证 Xcode 26.3。
+- Go、Node.js/npm。
+- XcodeGen 2.45 或更高版本：`brew install xcodegen`。
+
+如果 `xcode-select` 当前指向 Command Line Tools，可只为命令指定完整 Xcode：
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+```
+
+在仓库根目录执行：
+
+```bash
+make macos-app-test
+make macos-app-build-debug macos-app-build-release
+make macos-app-verify MACOS_CONFIGURATION=Debug
+make macos-app-verify MACOS_CONFIGURATION=Release
+```
+
+Debug 构建产物为 `macos/MSFMenuBar/DerivedData/Build/Products/Debug/MSF.app`。执行 `make macos-app-open` 可重新构建并打开 Debug App。Debug App 使用管理员授权的 legacy LaunchDaemon 安装器，只用于本地开发测试。

--- a/docs/install/unraid-plg.md
+++ b/docs/install/unraid-plg.md
@@ -4,14 +4,14 @@
 
 Unraid 版本支持 nftables 与 TUN；选择 TUN 时初始化预检会确认 `/dev/net/tun` 与运行权限。
 
-当前版本：`v0.3.9.5`
+当前版本：`v0.4.0`
 
 ## 安装
 
 在 Unraid WebGUI 中打开 **Plugins / Install Plugin**，填入插件地址：
 
 ```text
-https://github.com/scoltzero/msf/releases/download/v0.3.9.5/msf.plg
+https://github.com/scoltzero/msf/releases/download/v0.4.0/msf.plg
 ```
 
 安装完成后打开 **Settings / MSF Free**，进入轻量插件控制页，再点击打开 WebUI。完整管理界面运行在独立 WebUI 中，不嵌入 Unraid Settings 页面。
@@ -89,7 +89,7 @@ msf uninstall
 Unraid 发布资产包括：
 
 - `msf.plg`
-- `msf-0.3.9.5-x86_64-1.txz`
+- `msf-0.4.0-x86_64-1.txz`
 - 对应 `.sha256` 校验文件
 
 Unraid 打包开发说明见 [packaging/unraid/README.md](../../packaging/unraid/README.md)。运行目录和端口说明见 [运行参考](../reference/runtime.md)。

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -6,6 +6,7 @@
 - [fnOS FPK](../install/fnos-fpk.md)
 - [Unraid PLG](../install/unraid-plg.md)
 - [Docker 实验部署](../docker.md)
+- [macOS 菜单栏版](../install/macos.md)
 
 ## 数据目录
 
@@ -16,6 +17,7 @@
 | Unraid PLG | `/mnt/user/appdata/msf` |
 | Docker Compose / `docker-run.sh` 宿主机 | 默认当前目录的 `./msf-data` |
 | Docker 容器内 | `/opt/msf` |
+| macOS root LaunchDaemon | `/Library/Application Support/MSF` |
 | 源码本地非 root 运行 | 通常是 `./data`，取决于 `-c` / `--config` |
 
 主要目录结构：
@@ -28,6 +30,8 @@
 - `logs`
 - `database`
 - `backups`
+
+macOS 在 TUN 接管期间额外保存 `configs/network/darwin-state.json`，其中包含原始网络服务 DNS 与 `net.inet.ip.forwarding`。完全停止或守护进程正常退出时按快照恢复，而不是写死某个系统默认值。
 
 ## 服务端口分配
 
@@ -52,6 +56,18 @@
 | mihomo/sing-box | `9090` | 外部控制器 / Web 界面（zashboard） |
 
 host 网络模式下没有端口映射隔离，因此 Docker host TUN 宿主机上也不能已有进程占用启用中的端口。Linux TUN 模式默认不启用 `7877` / `7896`。
+
+macOS 后台管理页仅监听 `127.0.0.1:7777`；MosDNS 的 `53` 端口仍监听 LAN。macOS 不生成或加载 nftables，透明接管只使用 Mihomo `utun`、Fake-IP 路由、本机 DNS 与 IPv4 转发。
+
+统一 Network Runtime API 为：
+
+- `GET /api/v1/network/runtime`
+- `POST /api/v1/network/runtime/enable`
+- `POST /api/v1/network/runtime/disable`
+- `POST /api/v1/network/runtime/restart`
+- `POST /api/v1/network/runtime/stop`
+
+其中 `disable` 表示 TUN/DNS 保活的直连状态，`stop` 才会拆除系统网络接管并停止组件。
 
 ## 初始化后的运行状态
 

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -51,16 +51,24 @@ type App struct {
 
 	Services *ServiceManager
 
-	monitorMu          sync.Mutex
-	monitorNetworkLast monitorNetworkSample
-	appLogMu           sync.Mutex
-	mihomoTrafficMu    sync.Mutex
-	mihomoTrafficCache map[string]any
-	mihomoTrafficAt    time.Time
-	secretMu           sync.RWMutex
-	resetMu            sync.Mutex
-	resetGate          sync.RWMutex
-	resetInProgress    atomic.Bool
+	monitorMu               sync.Mutex
+	monitorNetworkLast      monitorNetworkSample
+	monitorNetworkCache     map[string]any
+	appLogMu                sync.Mutex
+	mihomoTrafficMu         sync.Mutex
+	mihomoTrafficCache      map[string]any
+	mihomoTrafficAt         time.Time
+	mihomoTrafficRefreshing bool
+	mihomoTrafficTotalsMu   sync.Mutex
+	mihomoTrafficTotalsLast mihomoTrafficTotalsSample
+	secretMu                sync.RWMutex
+	resetMu                 sync.Mutex
+	resetGate               sync.RWMutex
+	resetInProgress         atomic.Bool
+	networkRuntimeMu        sync.Mutex
+	networkStateMu          sync.RWMutex
+	networkTransition       string
+	networkLastError        string
 }
 
 type APIError struct {
@@ -323,6 +331,7 @@ func (a *App) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/system/diagnostics/run", a.handleDiagnosticsRun)
 	mux.HandleFunc("GET /api/v1/system/diagnostics/download", a.handleDiagnosticsDownload)
 	mux.HandleFunc("GET /api/v1/network/info", a.handleNetworkInfo)
+	a.registerNetworkRuntimeRoutes(mux)
 	mux.HandleFunc("POST /api/v1/network/apply", a.handleNFTApply)
 	mux.HandleFunc("POST /api/v1/network/stop", a.handleNFTClear)
 	mux.HandleFunc("GET /api/v1/netlink/nftables", a.handleNFTInfo)

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -356,6 +356,7 @@ func viewerAllows(method, path string) bool {
 		strings.HasPrefix(path, "/api/v1/history") ||
 		strings.HasPrefix(path, "/api/v1/mosdns") ||
 		strings.HasPrefix(path, "/api/v1/mihomo") ||
+		strings.HasPrefix(path, "/api/v1/network/runtime") ||
 		strings.HasPrefix(path, "/api/v1/network/info") ||
 		strings.HasPrefix(path, "/api/v1/netlink/nftables/status") ||
 		strings.HasPrefix(path, "/api/v1/system/diagnostics") ||
@@ -411,6 +412,7 @@ func readScopeAllows(method, path string) bool {
 		return true
 	}
 	if path == "/api/v1/version" ||
+		strings.HasPrefix(path, "/api/v1/network/runtime") ||
 		strings.HasPrefix(path, "/api/v1/monitor") ||
 		strings.HasPrefix(path, "/api/v1/services") ||
 		strings.HasPrefix(path, "/api/v1/logs") ||

--- a/internal/server/component_upload.go
+++ b/internal/server/component_upload.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"debug/elf"
+	"debug/macho"
 	"fmt"
 	"io"
 	"net/http"
@@ -166,23 +167,52 @@ func installZashboardArchive(src, uiDir string) error {
 }
 
 func validateUploadedLinuxBinary(path string) error {
-	if runtime.GOOS != "linux" {
+	switch runtime.GOOS {
+	case "linux":
+		f, err := elf.Open(path)
+		if err != nil {
+			return fmt.Errorf("uploaded binary is not a valid linux ELF file: %w", err)
+		}
+		defer f.Close()
+		switch runtime.GOARCH {
+		case "amd64":
+			if f.Machine != elf.EM_X86_64 {
+				return fmt.Errorf("uploaded binary architecture mismatch: got %s, want amd64", f.Machine.String())
+			}
+		case "arm64":
+			if f.Machine != elf.EM_AARCH64 {
+				return fmt.Errorf("uploaded binary architecture mismatch: got %s, want arm64", f.Machine.String())
+			}
+		}
+		return nil
+	case "darwin":
+		return validateUploadedMachOBinary(path, runtime.GOARCH)
+	default:
 		return nil
 	}
-	f, err := elf.Open(path)
+}
+
+func validateUploadedMachOBinary(path, goarch string) error {
+	want := macho.CpuArm64
+	if goarch == "amd64" {
+		want = macho.CpuAmd64
+	}
+	if fat, err := macho.OpenFat(path); err == nil {
+		defer fat.Close()
+		for _, arch := range fat.Arches {
+			if arch.Cpu == want {
+				return nil
+			}
+		}
+		return fmt.Errorf("uploaded universal Mach-O does not contain %s", goarch)
+	}
+	f, err := macho.Open(path)
 	if err != nil {
-		return fmt.Errorf("uploaded binary is not a valid linux ELF file: %w", err)
+		return fmt.Errorf("uploaded binary is not a valid macOS Mach-O file: %w", err)
 	}
 	defer f.Close()
-	switch runtime.GOARCH {
-	case "amd64":
-		if f.Machine != elf.EM_X86_64 {
-			return fmt.Errorf("uploaded binary architecture mismatch: got %s, want amd64", f.Machine.String())
-		}
-	case "arm64":
-		if f.Machine != elf.EM_AARCH64 {
-			return fmt.Errorf("uploaded binary architecture mismatch: got %s, want arm64", f.Machine.String())
-		}
+	if f.Cpu != want {
+		return fmt.Errorf("uploaded binary architecture mismatch: got %s, want %s", f.Cpu.String(), goarch)
 	}
 	return nil
 }
@@ -200,6 +230,23 @@ func findUploadedBinary(root, component string) string {
 		return nil
 	})
 	if best != "" {
+		return best
+	}
+	return findFirstNativeBinary(root)
+}
+
+func findFirstNativeBinary(root string) string {
+	if runtime.GOOS == "darwin" {
+		var best string
+		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || best != "" {
+				return nil
+			}
+			if err := validateUploadedMachOBinary(path, runtime.GOARCH); err == nil {
+				best = path
+			}
+			return nil
+		})
 		return best
 	}
 	return findFirstELF(root)

--- a/internal/server/configgen.go
+++ b/internal/server/configgen.go
@@ -70,7 +70,7 @@ func (c *SetupConfig) defaults() {
 		c.FakeIPRangeV6 = "f2b0::/18"
 	}
 	if c.LinuxProxyMode == "" {
-		if IsDockerRuntime() {
+		if IsDockerRuntime() || IsMacOSRuntime() {
 			c.LinuxProxyMode = "tun"
 		} else {
 			c.LinuxProxyMode = "nft"
@@ -83,6 +83,11 @@ func (c *SetupConfig) defaults() {
 		c.ProxyCore = "mihomo"
 	}
 	c.MosDNSEnabled = true
+	if IsMacOSRuntime() {
+		// The macOS daemon owns DNS while TUN is active and restores the
+		// captured system configuration on a full stop.
+		c.AutoSetDNS = true
+	}
 }
 
 func isTUNProxyMode(mode string) bool {
@@ -99,13 +104,17 @@ func isNFTProxyMode(mode string) bool {
 }
 
 func (a *App) ensureDefaultConfigs() error {
+	selectedInterface := defaultSetupInterface()
+	if selectedInterface == "" {
+		selectedInterface = "eth0"
+	}
 	cfg := SetupConfig{
 		Timezone:          "Asia/Shanghai",
 		WebPort:           "7777",
-		SelectedInterface: "eth0",
+		SelectedInterface: selectedInterface,
 		MihomoCoreType:    "meta",
 		AutoSetDNS:        true,
-		EnableIPv6:        true,
+		EnableIPv6:        !IsMacOSRuntime(),
 		ProxyCore:         "mihomo",
 		MosDNSEnabled:     true,
 	}
@@ -147,6 +156,7 @@ func (a *App) ensureDefaultConfigs() error {
 
 func (a *App) writeGeneratedConfigs(cfg SetupConfig) error {
 	cfg.defaults()
+	normalizeSetupInterfaceForRuntime(&cfg)
 	if err := a.ensureMSSBTemplateDefaults(true); err != nil {
 		return err
 	}
@@ -526,8 +536,11 @@ func renderMihomoTunYAML(cfg SetupConfig) string {
 	b.WriteString(`tun:
   enable: true
   stack: system
-  device: mihomo
-  auto-route: true
+`)
+	if !IsMacOSRuntime() {
+		b.WriteString("  device: mihomo\n")
+	}
+	b.WriteString(`  auto-route: true
   auto-detect-interface: true
   strict-route: false
   auto-redirect: false

--- a/internal/server/downloader.go
+++ b/internal/server/downloader.go
@@ -60,6 +60,16 @@ func (a *App) componentDownloadOptions() (string, bool) {
 func componentDownloadURLFor(component, goos, goarch, mihomoCoreType string, amd64v3 bool) string {
 	switch component {
 	case "mihomo":
+		if goos == "darwin" {
+			switch goarch {
+			case "arm64":
+				return "https://github.com/MetaCubeX/mihomo/releases/latest/download/mihomo-darwin-arm64.gz"
+			case "amd64":
+				return "https://github.com/MetaCubeX/mihomo/releases/latest/download/mihomo-darwin-amd64-compatible.gz"
+			default:
+				return ""
+			}
+		}
 		if goos != "linux" {
 			return ""
 		}
@@ -69,6 +79,14 @@ func componentDownloadURLFor(component, goos, goarch, mihomoCoreType string, amd
 		}
 		return fmt.Sprintf("https://github.com/baozaodetudou/mssb/releases/download/mihomo/mihomo-%s-linux-%s.tar.gz", normalizeMihomoCoreType(mihomoCoreType), arch)
 	case "mosdns":
+		if goos == "darwin" {
+			switch goarch {
+			case "amd64", "arm64":
+				return fmt.Sprintf("https://github.com/baozaodetudou/mssb/releases/download/mosdns/mosdns-darwin-%s.zip", goarch)
+			default:
+				return ""
+			}
+		}
 		if goos != "linux" {
 			return ""
 		}
@@ -123,8 +141,8 @@ func mosDNSAssetArch(goarch string, amd64v3 bool) string {
 
 func (a *App) installComponent(component string, emit func(DownloadEvent)) error {
 	component = normalizeComponent(component)
-	if runtime.GOOS != "linux" && component != "zashboard" && component != "ui" {
-		emit(DownloadEvent{Status: "skipped", Progress: 100, Message: "binary download is linux-only; place binary manually on this platform"})
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" && component != "zashboard" && component != "ui" {
+		emit(DownloadEvent{Status: "skipped", Progress: 100, Message: "binary download is unsupported on this platform; place binary manually"})
 		return nil
 	}
 	target := a.componentTarget(component)
@@ -175,6 +193,11 @@ func (a *App) installComponent(component string, emit func(DownloadEvent)) error
 	defer os.RemoveAll(extractDir)
 	if strings.HasSuffix(url, ".zip") {
 		if err := extractZipPreserve(tmp, extractDir); err != nil {
+			_ = os.Remove(tmp)
+			return err
+		}
+	} else if strings.HasSuffix(url, ".gz") && !strings.HasSuffix(url, ".tar.gz") {
+		if err := extractGzipBinary(tmp, filepath.Join(extractDir, component)); err != nil {
 			_ = os.Remove(tmp)
 			return err
 		}
@@ -248,6 +271,34 @@ func (a *App) componentTarget(component string) string {
 	default:
 		return ""
 	}
+}
+
+func extractGzipBinary(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	reader, err := gzip.NewReader(in)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, reader); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return os.Chmod(dst, 0755)
 }
 
 func (a *App) downloadFile(rawURL, dest string, emit func(DownloadEvent)) error {

--- a/internal/server/factory_reset.go
+++ b/internal/server/factory_reset.go
@@ -638,9 +638,14 @@ func (a *App) finishFactoryResetFiles(state factoryResetState) error {
 func (a *App) clearFactoryResetCaches() {
 	a.monitorMu.Lock()
 	a.monitorNetworkLast = monitorNetworkSample{}
+	a.monitorNetworkCache = nil
 	a.monitorMu.Unlock()
 	a.mihomoTrafficMu.Lock()
 	a.mihomoTrafficCache = nil
 	a.mihomoTrafficAt = time.Time{}
+	a.mihomoTrafficRefreshing = false
 	a.mihomoTrafficMu.Unlock()
+	a.mihomoTrafficTotalsMu.Lock()
+	a.mihomoTrafficTotalsLast = mihomoTrafficTotalsSample{}
+	a.mihomoTrafficTotalsMu.Unlock()
 }

--- a/internal/server/handlers_settings_structured.go
+++ b/internal/server/handlers_settings_structured.go
@@ -215,6 +215,11 @@ func applySetupStringDefaults(cfg *SetupConfig) {
 	if cfg.ProxyCore == "" || cfg.ProxyCore == "singbox" {
 		cfg.ProxyCore = "mihomo"
 	}
+	if IsMacOSRuntime() {
+		cfg.LinuxProxyMode = "tun"
+		cfg.AutoSetDNS = true
+		normalizeSetupInterfaceForRuntime(cfg)
+	}
 }
 
 func (a *App) applyStructuredAppearance(raw map[string]any) error {

--- a/internal/server/handlers_setup.go
+++ b/internal/server/handlers_setup.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -68,6 +69,16 @@ func (a *App) handleSetupSystemInfo(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleSetupNetworkInterfaces(w http.ResponseWriter, r *http.Request) {
 	ifaces, _ := net.Interfaces()
+	defaultInterface := defaultSetupInterface()
+	var darwinServiceDevices map[string]bool
+	if IsMacOSRuntime() {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		services, err := listDarwinNetworkServices(ctx)
+		cancel()
+		if err == nil {
+			darwinServiceDevices = enabledDarwinNetworkServiceDevices(services)
+		}
+	}
 	var out []map[string]any
 	for _, iface := range ifaces {
 		addrs, _ := iface.Addrs()
@@ -76,6 +87,10 @@ func (a *App) handleSetupNetworkInterfaces(w http.ResponseWriter, r *http.Reques
 			ips = append(ips, addr.String())
 		}
 		ip := primaryInterfaceIP(ips)
+		usable := iface.Flags&net.FlagUp != 0 && iface.Flags&net.FlagLoopback == 0 && ip != ""
+		if usable && IsMacOSRuntime() {
+			usable = darwinSetupInterfaceAllowed(iface.Name, darwinServiceDevices)
+		}
 		out = append(out, map[string]any{
 			"name":        iface.Name,
 			"index":       iface.Index,
@@ -86,6 +101,9 @@ func (a *App) handleSetupNetworkInterfaces(w http.ResponseWriter, r *http.Reques
 			"addresses":   ips,
 			"ip":          ip,
 			"primary_ip":  ip,
+			"is_usable":   usable,
+			"is_default":  iface.Name == defaultInterface,
+			"recommended": usable && iface.Name == defaultInterface,
 			"speed":       interfaceSpeed(iface.Name),
 		})
 	}
@@ -93,6 +111,10 @@ func (a *App) handleSetupNetworkInterfaces(w http.ResponseWriter, r *http.Reques
 }
 
 func (a *App) handleSetupPrivilege(w http.ResponseWriter, r *http.Request) {
+	message := "MosDNS 53 port and TUN/nftables require root on Linux"
+	if IsMacOSRuntime() {
+		message = "MosDNS 53 port, utun, DNS and forwarding changes require a root LaunchDaemon on macOS"
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,
 		"is_root": os.Geteuid() == 0,
@@ -100,8 +122,9 @@ func (a *App) handleSetupPrivilege(w http.ResponseWriter, r *http.Request) {
 		"runtime": map[string]any{
 			"docker":              IsDockerRuntime(),
 			"docker_network_mode": DockerNetworkMode(),
+			"macos":               IsMacOSRuntime(),
 		},
-		"message": "MosDNS 53 port and TUN/nftables require root on Linux",
+		"message": message,
 	})
 }
 
@@ -148,6 +171,7 @@ func (a *App) handleSetupPutConfig(w http.ResponseWriter, r *http.Request) {
 		preserveMissingGitHubDownloadFields(&cfg, meta, existing)
 	}
 	cfg.defaults()
+	normalizeSetupInterfaceForRuntime(&cfg)
 	if err := validateSetupProxyMode(cfg); err != nil {
 		writeError(w, http.StatusBadRequest, "unsupported_proxy_mode", err.Error())
 		return
@@ -306,6 +330,7 @@ func (a *App) handleSetupInitialize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cfg.defaults()
+	normalizeSetupInterfaceForRuntime(&cfg)
 	if err := validateSetupProxyMode(cfg); err != nil {
 		writeError(w, http.StatusBadRequest, "unsupported_proxy_mode", err.Error())
 		return
@@ -548,9 +573,26 @@ func setupBool(raw map[string]any, fallback bool, keys ...string) bool {
 }
 
 func defaultSetupInterface() string {
+	if IsMacOSRuntime() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		services, servicesErr := listDarwinNetworkServices(ctx)
+		defaultRoute, _ := darwinDefaultRouteInterface(ctx)
+		if servicesErr == nil {
+			if name := chooseDarwinSetupInterface(defaultRoute, services, setupInterfaceHasUsableIP); name != "" {
+				return name
+			}
+		}
+		if name := strings.TrimSpace(defaultRoute); name != "" && !isDarwinVirtualSetupInterface(name) && setupInterfaceHasUsableIP(name) {
+			return name
+		}
+	}
 	ifaces, _ := net.Interfaces()
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if IsMacOSRuntime() && isDarwinVirtualSetupInterface(iface.Name) {
 			continue
 		}
 		addrs, _ := iface.Addrs()
@@ -563,6 +605,93 @@ func defaultSetupInterface() string {
 		}
 	}
 	return ""
+}
+
+func normalizeSetupInterfaceForRuntime(cfg *SetupConfig) {
+	if cfg == nil || !IsMacOSRuntime() {
+		return
+	}
+	selected := strings.TrimSpace(cfg.SelectedInterface)
+	if selected != "" && setupInterfaceUsableForRuntime(selected) {
+		cfg.SelectedInterface = selected
+		return
+	}
+	if fallback := defaultSetupInterface(); fallback != "" {
+		cfg.SelectedInterface = fallback
+	}
+}
+
+func setupInterfaceHasUsableIP(name string) bool {
+	iface, err := net.InterfaceByName(strings.TrimSpace(name))
+	if err != nil || iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+		return false
+	}
+	return primaryIPForInterface(iface.Name) != ""
+}
+
+func setupInterfaceUsableForRuntime(name string) bool {
+	name = strings.TrimSpace(name)
+	if !setupInterfaceHasUsableIP(name) {
+		return false
+	}
+	if !IsMacOSRuntime() {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	services, err := listDarwinNetworkServices(ctx)
+	if err == nil {
+		return enabledDarwinNetworkServiceDevices(services)[name]
+	}
+	return !isDarwinVirtualSetupInterface(name)
+}
+
+func chooseDarwinSetupInterface(defaultRoute string, services []darwinNetworkService, usable func(string) bool) string {
+	if usable == nil {
+		return ""
+	}
+	devices := enabledDarwinNetworkServiceDevices(services)
+	defaultRoute = strings.TrimSpace(defaultRoute)
+	if devices[defaultRoute] && usable(defaultRoute) {
+		return defaultRoute
+	}
+	for _, service := range services {
+		device := strings.TrimSpace(service.Device)
+		if service.Disabled || device == "" || !devices[device] || !usable(device) {
+			continue
+		}
+		return device
+	}
+	return ""
+}
+
+func enabledDarwinNetworkServiceDevices(services []darwinNetworkService) map[string]bool {
+	devices := make(map[string]bool, len(services))
+	for _, service := range services {
+		device := strings.TrimSpace(service.Device)
+		if !service.Disabled && device != "" {
+			devices[device] = true
+		}
+	}
+	return devices
+}
+
+func darwinSetupInterfaceAllowed(name string, serviceDevices map[string]bool) bool {
+	name = strings.TrimSpace(name)
+	if len(serviceDevices) > 0 {
+		return serviceDevices[name]
+	}
+	return !isDarwinVirtualSetupInterface(name)
+}
+
+func isDarwinVirtualSetupInterface(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	for _, prefix := range []string{"lo", "gif", "stf", "utun", "anpi", "awdl", "llw", "ap", "p2p", "ipsec", "tap", "tun", "vmenet", "vmnet"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *App) handleSetupActivate(w http.ResponseWriter, r *http.Request) {
@@ -796,7 +925,28 @@ func hostname() string {
 	return h
 }
 
+var (
+	cpuModelOnce  sync.Once
+	cpuModelValue string
+)
+
 func cpuModel() string {
+	cpuModelOnce.Do(func() {
+		cpuModelValue = detectCPUModel()
+	})
+	return firstNonEmpty(cpuModelValue, runtime.GOARCH)
+}
+
+func detectCPUModel() string {
+	if runtime.GOOS == "darwin" {
+		for _, key := range []string{"machdep.cpu.brand_string", "hw.model"} {
+			out, err := commandOutput(time.Second, "/usr/sbin/sysctl", "-n", key)
+			if err == nil && strings.TrimSpace(string(out)) != "" {
+				return strings.TrimSpace(string(out))
+			}
+		}
+		return runtime.GOARCH
+	}
 	if runtime.GOOS != "linux" {
 		return runtime.GOARCH
 	}

--- a/internal/server/handlers_system.go
+++ b/internal/server/handlers_system.go
@@ -41,12 +41,21 @@ func (a *App) handleMonitorNetwork(w http.ResponseWriter, r *http.Request) {
 func (a *App) handleMonitorHistory(w http.ResponseWriter, r *http.Request) {
 	mem := readMemInfo()
 	now := time.Now()
+	memUsed := uint64(0)
+	if mem["MemTotal"] >= mem["MemAvailable"] {
+		memUsed = mem["MemTotal"] - mem["MemAvailable"]
+	}
+	network := a.monitorNetworkSnapshot(now)
 	point := map[string]any{
-		"time":           now.Format(time.RFC3339),
-		"timestamp":      now.Unix(),
-		"cpu_percent":    sampleCPUPercent(),
-		"memory_percent": percent(mem["MemTotal"]-mem["MemAvailable"], mem["MemTotal"]),
-		"network":        readNetworkCounters(),
+		"time":             now.Format(time.RFC3339),
+		"timestamp":        now.Unix(),
+		"cpu_percent":      sampleCPUPercent(),
+		"memory_percent":   percent(memUsed, mem["MemTotal"]),
+		"network":          network,
+		"download_speed":   network["download_speed"],
+		"upload_speed":     network["upload_speed"],
+		"connections":      network["connections"],
+		"connection_count": network["connection_count"],
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"success": true, "data": []any{point}})
 }
@@ -786,6 +795,9 @@ func (a *App) handleLicenseNoop(w http.ResponseWriter, r *http.Request) {
 }
 
 func readMemInfo() map[string]uint64 {
+	if runtime.GOOS == "darwin" {
+		return readDarwinMemInfo()
+	}
 	out := map[string]uint64{"MemTotal": 0, "MemAvailable": 0}
 	b, err := os.ReadFile("/proc/meminfo")
 	if err != nil {

--- a/internal/server/handlers_update.go
+++ b/internal/server/handlers_update.go
@@ -893,6 +893,18 @@ func (a *App) componentUpdateState(component string) map[string]any {
 }
 
 func (a *App) componentRemoteInfo(component string) (githubRelease, error) {
+	if runtime.GOOS == "darwin" {
+		switch normalizeComponent(component) {
+		case "mosdns":
+			return a.fetchReleaseByTag("baozaodetudou", "mssb", "mosdns")
+		case "mihomo":
+			return a.fetchLatestRelease("MetaCubeX", "mihomo")
+		case "zashboard":
+			return a.fetchLatestRelease("Zephyruso", "zashboard")
+		default:
+			return githubRelease{}, fmt.Errorf("unknown component %s", component)
+		}
+	}
 	switch normalizeComponent(component) {
 	case "mosdns":
 		return a.fetchReleaseByTag("baozaodetudou", "mssb", "mosdns")
@@ -1488,6 +1500,28 @@ func (a *App) componentReleaseAssetURL(release githubRelease, component string) 
 }
 
 func (a *App) componentReleaseAsset(release githubRelease, component string) (githubAsset, bool) {
+	if runtime.GOOS == "darwin" {
+		component = normalizeComponent(component)
+		want := ""
+		switch component {
+		case "mosdns":
+			want = "mosdns-darwin-" + runtime.GOARCH + ".zip"
+		case "mihomo":
+			tag := strings.TrimSpace(release.TagName)
+			if runtime.GOARCH == "arm64" {
+				want = "mihomo-darwin-arm64-" + tag + ".gz"
+			} else if runtime.GOARCH == "amd64" {
+				want = "mihomo-darwin-amd64-compatible-" + tag + ".gz"
+			}
+		}
+		if want != "" {
+			for _, asset := range release.Assets {
+				if strings.EqualFold(asset.Name, want) {
+					return asset, true
+				}
+			}
+		}
+	}
 	want := downloadAssetName(a.componentDownloadURL(component))
 	if want == "" {
 		return githubAsset{}, false

--- a/internal/server/mihomo_panels.go
+++ b/internal/server/mihomo_panels.go
@@ -44,8 +44,8 @@ func (a *App) mihomoFullSnapshot() map[string]any {
 	cfg := a.mihomoConfigMap()
 	service := a.Services.Status("mihomo")
 	controllerCfg := a.mihomoControllerConfig()
-	traffic := a.mihomoTrafficPayload()
 	connections := a.mihomoConnectionsPayload(nil)
+	traffic := a.mihomoTrafficFromConnections(connections, time.Now())
 	proxies := a.mihomoProxiesPayload(nil)
 	rules := a.mihomoRulesRuntime(nil)
 	providers := a.mihomoProvidersPayload()
@@ -122,7 +122,7 @@ func (a *App) mihomoOverviewSnapshot() map[string]any {
 	service := a.Services.Status("mihomo")
 	controllerCfg := a.mihomoControllerConfig()
 	connections := a.mihomoConnectionsSummary()
-	traffic := a.mihomoTrafficCachedPayload()
+	traffic := a.mihomoTrafficFromConnections(connections, time.Now())
 	version := a.mihomoVersion()
 	if raw, ok, _ := a.mihomoControllerJSON(http.MethodGet, "/version", nil); ok {
 		if m, ok := raw.(map[string]any); ok {
@@ -380,26 +380,121 @@ func mihomoPortsFromConfig(cfg map[string]any) map[string]int {
 
 const mihomoTrafficCacheTTL = 2 * time.Second
 
-func (a *App) mihomoTrafficPayload() map[string]any {
-	if cached, ok := a.cachedMihomoTraffic(); ok {
+const mihomoTrafficMinSampleInterval = 750 * time.Millisecond
+
+type mihomoTrafficTotalsSample struct {
+	At            time.Time
+	DownloadTotal float64
+	UploadTotal   float64
+	DownloadRate  float64
+	UploadRate    float64
+}
+
+func (a *App) mihomoTrafficFromConnections(connections map[string]any, now time.Time) map[string]any {
+	if !boolMapValue(connections, "available", true) {
+		return a.mihomoTrafficCachedPayload()
+	}
+	if cached, ok := a.cachedMihomoTraffic(); ok && stringMapValue(cached, "source") == "traffic" {
 		return cached
 	}
-	payload := a.fetchMihomoTrafficPayload()
+	payload := a.deriveMihomoTrafficFromTotals(
+		numericMapValue(connections, "downloadTotal"),
+		numericMapValue(connections, "uploadTotal"),
+		now,
+	)
+	a.storeMihomoTraffic(payload)
+	return payload
+}
+
+func (a *App) deriveMihomoTrafficFromTotals(downloadTotal, uploadTotal float64, now time.Time) map[string]any {
+	a.mihomoTrafficTotalsMu.Lock()
+	last := a.mihomoTrafficTotalsLast
+	downloadRate, uploadRate := float64(0), float64(0)
+	if !last.At.IsZero() && now.After(last.At) {
+		elapsed := now.Sub(last.At).Seconds()
+		if elapsed < mihomoTrafficMinSampleInterval.Seconds() {
+			downloadRate = last.DownloadRate
+			uploadRate = last.UploadRate
+			a.mihomoTrafficTotalsMu.Unlock()
+			return mihomoTrafficRatePayload(uploadRate, downloadRate, uploadTotal, downloadTotal, "connections")
+		}
+		if downloadTotal >= last.DownloadTotal {
+			downloadRate = (downloadTotal - last.DownloadTotal) / elapsed
+		}
+		if uploadTotal >= last.UploadTotal {
+			uploadRate = (uploadTotal - last.UploadTotal) / elapsed
+		}
+	}
+	a.mihomoTrafficTotalsLast = mihomoTrafficTotalsSample{
+		At:            now,
+		DownloadTotal: downloadTotal,
+		UploadTotal:   uploadTotal,
+		DownloadRate:  downloadRate,
+		UploadRate:    uploadRate,
+	}
+	a.mihomoTrafficTotalsMu.Unlock()
+	return mihomoTrafficRatePayload(uploadRate, downloadRate, uploadTotal, downloadTotal, "connections")
+}
+
+func mihomoTrafficRatePayload(uploadRate, downloadRate, uploadTotal, downloadTotal float64, source string) map[string]any {
+	return map[string]any{
+		"up":             uploadRate,
+		"down":           downloadRate,
+		"upload":         uploadRate,
+		"download":       downloadRate,
+		"uploadTotal":    uploadTotal,
+		"downloadTotal":  downloadTotal,
+		"upload_total":   uploadTotal,
+		"download_total": downloadTotal,
+		"source":         source,
+		"raw":            map[string]any{},
+	}
+}
+
+func (a *App) mihomoTrafficPayload() map[string]any {
+	payload, ok := a.fetchMihomoTrafficPayloadResult()
+	if !ok {
+		a.mihomoTrafficMu.Lock()
+		cached := cloneAnyMap(a.mihomoTrafficCache)
+		hasCached := a.mihomoTrafficCache != nil
+		a.mihomoTrafficMu.Unlock()
+		if hasCached {
+			return cached
+		}
+		return zeroMihomoTrafficPayload()
+	}
 	a.storeMihomoTraffic(payload)
 	return payload
 }
 
 func (a *App) mihomoTrafficCachedPayload() map[string]any {
-	if cached, ok := a.cachedMihomoTraffic(); ok {
+	a.mihomoTrafficMu.Lock()
+	hasCached := a.mihomoTrafficCache != nil && !a.mihomoTrafficAt.IsZero()
+	stale := hasCached && time.Since(a.mihomoTrafficAt) > mihomoTrafficCacheTTL
+	cached := cloneAnyMap(a.mihomoTrafficCache)
+	refresh := (!hasCached || stale) && !a.mihomoTrafficRefreshing
+	if refresh {
+		a.mihomoTrafficRefreshing = true
+	}
+	a.mihomoTrafficMu.Unlock()
+	if refresh {
+		go a.refreshMihomoTrafficCache()
+	}
+	if hasCached {
 		return cached
 	}
-	go a.refreshMihomoTrafficCache()
 	return zeroMihomoTrafficPayload()
 }
 
 func (a *App) refreshMihomoTrafficCache() {
-	payload := a.fetchMihomoTrafficPayload()
-	a.storeMihomoTraffic(payload)
+	payload, ok := a.fetchMihomoTrafficPayloadResult()
+	a.mihomoTrafficMu.Lock()
+	defer a.mihomoTrafficMu.Unlock()
+	if ok {
+		a.mihomoTrafficCache = cloneAnyMap(payload)
+		a.mihomoTrafficAt = time.Now()
+	}
+	a.mihomoTrafficRefreshing = false
 }
 
 func (a *App) cachedMihomoTraffic() (map[string]any, bool) {
@@ -419,16 +514,32 @@ func (a *App) storeMihomoTraffic(payload map[string]any) {
 }
 
 func (a *App) fetchMihomoTrafficPayload() map[string]any {
+	payload, ok := a.fetchMihomoTrafficPayloadResult()
+	if !ok {
+		return zeroMihomoTrafficPayload()
+	}
+	return payload
+}
+
+func (a *App) fetchMihomoTrafficPayloadResult() (map[string]any, bool) {
 	if raw, ok := a.mihomoControllerMap("/traffic"); ok {
 		return map[string]any{
 			"up":       numericMapValue(raw, "up"),
 			"down":     numericMapValue(raw, "down"),
 			"upload":   numericMapValue(raw, "up"),
 			"download": numericMapValue(raw, "down"),
+			"source":   "traffic",
 			"raw":      raw,
-		}
+		}, true
 	}
-	return zeroMihomoTrafficPayload()
+	if raw, ok := a.mihomoControllerMap("/connections"); ok {
+		return a.deriveMihomoTrafficFromTotals(
+			numericMapValue(raw, "downloadTotal"),
+			numericMapValue(raw, "uploadTotal"),
+			time.Now(),
+		), true
+	}
+	return nil, false
 }
 
 func zeroMihomoTrafficPayload() map[string]any {
@@ -447,11 +558,12 @@ func (a *App) mihomoConnectionsSummary() map[string]any {
 	raw, ok := a.mihomoControllerMap("/connections")
 	if !ok {
 		return map[string]any{
-			"total": 0, "active_count": 0, "downloadTotal": 0, "uploadTotal": 0, "download_total": 0, "upload_total": 0,
+			"available": false, "total": 0, "active_count": 0, "downloadTotal": 0, "uploadTotal": 0, "download_total": 0, "upload_total": 0,
 		}
 	}
 	total := len(anySlice(raw["connections"]))
 	return map[string]any{
+		"available":      true,
 		"total":          total,
 		"active_count":   total,
 		"downloadTotal":  numericMapValue(raw, "downloadTotal"),
@@ -462,8 +574,8 @@ func (a *App) mihomoConnectionsSummary() map[string]any {
 }
 
 func (a *App) mihomoConnectionsPayload(r *http.Request) map[string]any {
-	raw, ok := a.mihomoControllerMap("/connections")
-	if !ok {
+	raw, available := a.mihomoControllerMap("/connections")
+	if !available {
 		raw = map[string]any{"connections": []any{}, "downloadTotal": 0, "uploadTotal": 0}
 	}
 	connections := normalizeMihomoConnectionList(anySlice(raw["connections"]))
@@ -487,6 +599,7 @@ func (a *App) mihomoConnectionsPayload(r *http.Request) map[string]any {
 	}
 	items := filtered[start:end]
 	return map[string]any{
+		"available":      available,
 		"connections":    items,
 		"items":          items,
 		"total":          total,

--- a/internal/server/monitor_payload.go
+++ b/internal/server/monitor_payload.go
@@ -143,9 +143,22 @@ func (a *App) monitorResourceSnapshot() map[string]any {
 	cpuPercent := sampleCPUPercent()
 	memPercent := percent(memUsed, memTotal)
 	diskPercent := numericAny(disk["percent"])
+	cpuModelName := cpuModel()
+	cpuCores := runtime.NumCPU()
+	hardware := map[string]any{
+		"cpu_model":    cpuModelName,
+		"cpu_cores":    cpuCores,
+		"cores":        cpuCores,
+		"memory_total": memTotal,
+		"disk_total":   diskTotal,
+	}
 	return map[string]any{
 		"cpu_percent":    cpuPercent,
 		"cpu":            cpuPercent,
+		"cpu_model":      cpuModelName,
+		"cpu_cores":      cpuCores,
+		"cores":          cpuCores,
+		"hardware":       hardware,
 		"memory_total":   memTotal,
 		"memory_free":    memAvailable,
 		"memory_used":    memUsed,
@@ -162,20 +175,54 @@ func (a *App) monitorResourceSnapshot() map[string]any {
 	}
 }
 
+const monitorNetworkMinSampleInterval = 750 * time.Millisecond
+
 func (a *App) monitorNetworkSnapshot(now time.Time) map[string]any {
 	interfaces := readNetworkCounters()
 	var rxTotal, txTotal uint64
 	for _, item := range interfaces {
-		if stringMapValue(item, "name") == "lo" {
+		if isLoopbackNetworkInterface(stringMapValue(item, "name")) {
 			continue
 		}
 		rxTotal += uint64FromAny(item["rx_bytes"])
 		txTotal += uint64FromAny(item["tx_bytes"])
 	}
 
-	var downloadSpeed, uploadSpeed float64
+	connectionCount, mihomoDownloadTotal, mihomoUploadTotal := a.monitorMihomoConnectionSummary()
+	payload := map[string]any{
+		"local_ips":             localIPs(),
+		"interfaces":            interfaces,
+		"rx_bytes":              rxTotal,
+		"tx_bytes":              txTotal,
+		"total_download":        rxTotal,
+		"total_upload":          txTotal,
+		"download_total":        rxTotal,
+		"upload_total":          txTotal,
+		"download_speed":        float64(0),
+		"upload_speed":          float64(0),
+		"down_speed":            float64(0),
+		"up_speed":              float64(0),
+		"downloadSpeed":         float64(0),
+		"uploadSpeed":           float64(0),
+		"connections":           connectionCount,
+		"connection_count":      connectionCount,
+		"mihomo_download_total": mihomoDownloadTotal,
+		"mihomo_upload_total":   mihomoUploadTotal,
+		"mihomo_downloadTotal":  mihomoDownloadTotal,
+		"mihomo_uploadTotal":    mihomoUploadTotal,
+	}
+
 	a.monitorMu.Lock()
 	last := a.monitorNetworkLast
+	if a.monitorNetworkCache != nil && !last.At.IsZero() && (!now.After(last.At) || now.Sub(last.At) < monitorNetworkMinSampleInterval) {
+		for _, key := range []string{"download_speed", "upload_speed", "down_speed", "up_speed", "downloadSpeed", "uploadSpeed"} {
+			payload[key] = a.monitorNetworkCache[key]
+		}
+		a.monitorNetworkCache = cloneAnyMap(payload)
+		a.monitorMu.Unlock()
+		return payload
+	}
+	var downloadSpeed, uploadSpeed float64
 	if !last.At.IsZero() && now.After(last.At) {
 		elapsed := now.Sub(last.At).Seconds()
 		if elapsed > 0 {
@@ -188,31 +235,19 @@ func (a *App) monitorNetworkSnapshot(now time.Time) map[string]any {
 		}
 	}
 	a.monitorNetworkLast = monitorNetworkSample{At: now, RXBytes: rxTotal, TXBytes: txTotal}
+	payload["download_speed"] = downloadSpeed
+	payload["upload_speed"] = uploadSpeed
+	payload["down_speed"] = downloadSpeed
+	payload["up_speed"] = uploadSpeed
+	payload["downloadSpeed"] = downloadSpeed
+	payload["uploadSpeed"] = uploadSpeed
+	a.monitorNetworkCache = cloneAnyMap(payload)
 	a.monitorMu.Unlock()
+	return payload
+}
 
-	connectionCount, mihomoDownloadTotal, mihomoUploadTotal := a.monitorMihomoConnectionSummary()
-	return map[string]any{
-		"local_ips":             localIPs(),
-		"interfaces":            interfaces,
-		"rx_bytes":              rxTotal,
-		"tx_bytes":              txTotal,
-		"total_download":        rxTotal,
-		"total_upload":          txTotal,
-		"download_total":        rxTotal,
-		"upload_total":          txTotal,
-		"download_speed":        downloadSpeed,
-		"upload_speed":          uploadSpeed,
-		"down_speed":            downloadSpeed,
-		"up_speed":              uploadSpeed,
-		"downloadSpeed":         downloadSpeed,
-		"uploadSpeed":           uploadSpeed,
-		"connections":           connectionCount,
-		"connection_count":      connectionCount,
-		"mihomo_download_total": mihomoDownloadTotal,
-		"mihomo_upload_total":   mihomoUploadTotal,
-		"mihomo_downloadTotal":  mihomoDownloadTotal,
-		"mihomo_uploadTotal":    mihomoUploadTotal,
-	}
+func isLoopbackNetworkInterface(name string) bool {
+	return name == "lo" || name == "lo0"
 }
 
 func (a *App) monitorMihomoConnectionSummary() (float64, float64, float64) {

--- a/internal/server/mosdns_observability.go
+++ b/internal/server/mosdns_observability.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 )
 
 var (
@@ -78,9 +79,14 @@ func normalizeMosDNSQueryArray(items []any) []map[string]any {
 	for i, item := range items {
 		switch v := item.(type) {
 		case map[string]any:
-			out = append(out, normalizeMosDNSQueryMap(v, i, ""))
+			entry := normalizeMosDNSQueryMap(v, i, "")
+			if stringMapValue(entry, "query_name") != "" {
+				out = append(out, entry)
+			}
 		case string:
-			out = append(out, parseMosDNSQueryLine(v, i))
+			if entry, ok := parseMosDNSQueryLine(v, i); ok {
+				out = append(out, entry)
+			}
 		}
 	}
 	return out
@@ -97,19 +103,25 @@ func parseMosDNSQueryEntries(lines []string) []map[string]any {
 			var obj map[string]any
 			if json.Unmarshal([]byte(line[start:]), &obj) == nil && len(obj) > 0 {
 				entry := normalizeMosDNSQueryMap(obj, i, line)
-				if entry["query_name"] != "" {
+				if stringMapValue(entry, "query_name") != "" {
 					entries = append(entries, entry)
-					continue
 				}
+				continue
 			}
 		}
-		entries = append(entries, parseMosDNSQueryLine(line, i))
+		if entry, ok := parseMosDNSQueryLine(line, i); ok {
+			entries = append(entries, entry)
+		}
 	}
 	return entries
 }
 
 func normalizeMosDNSQueryMap(obj map[string]any, index int, raw string) map[string]any {
-	queryName := firstString(obj, "query_name", "query", "domain", "name", "qname", "host")
+	explicitQueryName := firstString(obj, "query_name", "query", "domain", "qname")
+	queryName := explicitQueryName
+	if queryName == "" {
+		queryName = firstString(obj, "name", "host")
+	}
 	clientIP := firstString(obj, "client_ip", "client", "client_addr", "remote_addr", "src")
 	queryType := strings.ToUpper(firstString(obj, "query_type", "qtype", "type"))
 	domainSet := firstString(obj, "domain_set", "rule", "matched_rule", "tag", "plugin", "matcher")
@@ -122,8 +134,12 @@ func normalizeMosDNSQueryMap(obj map[string]any, index int, raw string) map[stri
 	if queryName == "" && raw != "" {
 		queryName = extractDomainLike(raw)
 	}
+	queryName = normalizeMosDNSQueryName(queryName)
 	if clientIP == "" && raw != "" {
 		clientIP = firstIPv4(raw)
+	}
+	if queryName == "" || (explicitQueryName == "" && queryType == "" && clientIP == "" && len(answers) == 0) {
+		return map[string]any{}
 	}
 	if queryType == "" {
 		queryType = "A"
@@ -142,8 +158,8 @@ func normalizeMosDNSQueryMap(obj map[string]any, index int, raw string) map[stri
 		"trace_id":      nonEmpty(firstString(obj, "trace_id", "id"), fmt.Sprintf("log-%d", index+1)),
 		"query_time":    queryTime,
 		"time":          queryTime,
-		"query_name":    trimQueryName(queryName, raw),
-		"domain":        trimQueryName(queryName, raw),
+		"query_name":    queryName,
+		"domain":        queryName,
 		"client_ip":     nonEmpty(clientIP, "127.0.0.1"),
 		"client":        nonEmpty(clientIP, "127.0.0.1"),
 		"query_type":    queryType,
@@ -158,7 +174,7 @@ func normalizeMosDNSQueryMap(obj map[string]any, index int, raw string) map[stri
 	}
 }
 
-func parseMosDNSQueryLine(line string, index int) map[string]any {
+func parseMosDNSQueryLine(line string, index int) (map[string]any, bool) {
 	values := map[string]string{}
 	for _, match := range keyValuePattern.FindAllStringSubmatch(line, -1) {
 		if len(match) >= 3 {
@@ -175,6 +191,7 @@ func parseMosDNSQueryLine(line string, index int) map[string]any {
 	if queryName == "" {
 		queryName = extractDomainLike(line)
 	}
+	queryName = normalizeMosDNSQueryName(queryName)
 	clientIP := values["client_ip"]
 	if clientIP == "" {
 		clientIP = values["client"]
@@ -216,6 +233,11 @@ func parseMosDNSQueryLine(line string, index int) map[string]any {
 		duration = firstDurationMS(line)
 	}
 	answers := parseAnswers(line)
+	explicitQueryName := values["query_name"] != "" || values["query"] != "" || values["domain"] != ""
+	queryEvidence := explicitQueryName || (queryName != "" && queryType != "" && (clientIP != "" || responseCode != "" || duration > 0 || len(answers) > 0))
+	if queryName == "" || !queryEvidence {
+		return nil, false
+	}
 	if queryType == "" {
 		queryType = "A"
 	}
@@ -230,8 +252,8 @@ func parseMosDNSQueryLine(line string, index int) map[string]any {
 		"trace_id":      fmt.Sprintf("log-%d", index+1),
 		"query_time":    queryTime,
 		"time":          queryTime,
-		"query_name":    trimQueryName(queryName, line),
-		"domain":        trimQueryName(queryName, line),
+		"query_name":    queryName,
+		"domain":        queryName,
 		"client_ip":     nonEmpty(clientIP, "127.0.0.1"),
 		"client":        nonEmpty(clientIP, "127.0.0.1"),
 		"query_type":    queryType,
@@ -243,7 +265,7 @@ func parseMosDNSQueryLine(line string, index int) map[string]any {
 		"duration_ms":   duration,
 		"answers":       answers,
 		"raw":           line,
-	}
+	}, true
 }
 
 func filterMosDNSQueryEntries(entries []map[string]any, r *http.Request) []map[string]any {
@@ -597,13 +619,23 @@ func firstIPv4(line string) string {
 	return ""
 }
 
-func trimQueryName(name, fallback string) string {
-	name = strings.Trim(strings.TrimSpace(name), ".")
-	if name == "" {
-		name = extractDomainLike(fallback)
+func normalizeMosDNSQueryName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.Trim(name, `"'[](){},;`)
+	name = strings.TrimSuffix(name, ".")
+	if name == "" || len(name) > 253 || strings.Contains(name, "..") {
+		return ""
 	}
-	if len(name) > 180 {
-		return name[:180]
+	for _, label := range strings.Split(name, ".") {
+		if label == "" || len(label) > 63 {
+			return ""
+		}
+		for _, r := range label {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' {
+				continue
+			}
+			return ""
+		}
 	}
 	return name
 }

--- a/internal/server/mosdns_observability_test.go
+++ b/internal/server/mosdns_observability_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMosDNSQueryParsingSkipsServiceLogs(t *testing.T) {
+	lines := []string{
+		`2026-07-29T18:50:55.302+0800 INFO starting proxy at 127.0.0.1:7891`,
+		`loaded rules from client_ip.txt`,
+		`compiled regexp:^240[0-9a-f]-.*\.free-lbv6\.idouyinvod\.com$`,
+		`{"level":"info","time":"2026-07-29T18:50:55.302+08:00","msg":"loaded","name":"client_ip.txt"}`,
+		`client_ip=192.168.10.223 query_name=valid.example qtype=A rule=unmatched_rule rcode=NOERROR duration=0.25ms`,
+		`2026-07-29 18:50:56 query AAAA ipv6.example from 192.168.10.224 cost 1.5ms`,
+	}
+
+	entries := parseMosDNSQueryEntries(lines)
+	if len(entries) != 2 {
+		t.Fatalf("expected only query records, got %d: %#v", len(entries), entries)
+	}
+	if got := stringMapValue(entries[0], "query_name"); got != "valid.example" {
+		t.Fatalf("explicit query name=%q", got)
+	}
+	if got := stringMapValue(entries[1], "query_name"); got != "ipv6.example" {
+		t.Fatalf("fallback query name=%q", got)
+	}
+}
+
+func TestMosDNSQueryFilteringDoesNotDuplicateRows(t *testing.T) {
+	entries := parseMosDNSQueryEntries([]string{
+		`client_ip=192.168.10.2 query_name=one.example qtype=A rule=direct rcode=NOERROR`,
+		`client_ip=192.168.10.3 query_name=two.example qtype=AAAA rule=direct rcode=NOERROR`,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mosdns/query-log", nil)
+	filtered := filterMosDNSQueryEntries(entries, req)
+	if len(filtered) != len(entries) {
+		t.Fatalf("query filtering changed row count: got=%d want=%d", len(filtered), len(entries))
+	}
+}
+
+func TestNormalizeMosDNSQueryNameRejectsNonDomains(t *testing.T) {
+	for _, value := range []string{
+		"2026-07-29T18:50:55.302+0800",
+		"127.0.0.1:7891",
+		`regexp:^ntp[1-2]?\..*\.com$`,
+	} {
+		if got := normalizeMosDNSQueryName(value); got != "" {
+			t.Fatalf("normalizeMosDNSQueryName(%q)=%q, want empty", value, got)
+		}
+	}
+	for _, value := range []string{"example.com", "_dns._udp.example.com", "域名.中国"} {
+		if got := normalizeMosDNSQueryName(value); got != value {
+			t.Fatalf("normalizeMosDNSQueryName(%q)=%q", value, got)
+		}
+	}
+}

--- a/internal/server/network_runtime.go
+++ b/internal/server/network_runtime.go
@@ -1,0 +1,306 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	networkRuntimeDesiredKey = "network.runtime.desired"
+	networkRuntimeUpdatedKey = "network.runtime.updated_at"
+	runtimeStateEnabled      = "enabled"
+	runtimeStateDirect       = "direct"
+	runtimeStateStopped      = "stopped"
+)
+
+func (a *App) registerNetworkRuntimeRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/network/runtime", a.handleNetworkRuntime)
+	mux.HandleFunc("POST /api/v1/network/runtime/enable", a.handleNetworkRuntimeEnable)
+	mux.HandleFunc("POST /api/v1/network/runtime/disable", a.handleNetworkRuntimeDisable)
+	mux.HandleFunc("POST /api/v1/network/runtime/restart", a.handleNetworkRuntimeRestart)
+	mux.HandleFunc("POST /api/v1/network/runtime/stop", a.handleNetworkRuntimeStop)
+}
+
+func (a *App) handleNetworkRuntime(w http.ResponseWriter, r *http.Request) {
+	data := a.networkRuntimeSnapshot(r.Context())
+	writeJSON(w, http.StatusOK, map[string]any{"success": true, "data": data})
+}
+
+func (a *App) handleNetworkRuntimeEnable(w http.ResponseWriter, r *http.Request) {
+	a.handleNetworkRuntimeAction(w, r, "enable")
+}
+
+func (a *App) handleNetworkRuntimeDisable(w http.ResponseWriter, r *http.Request) {
+	a.handleNetworkRuntimeAction(w, r, "disable")
+}
+
+func (a *App) handleNetworkRuntimeRestart(w http.ResponseWriter, r *http.Request) {
+	a.handleNetworkRuntimeAction(w, r, "restart")
+}
+
+func (a *App) handleNetworkRuntimeStop(w http.ResponseWriter, r *http.Request) {
+	a.handleNetworkRuntimeAction(w, r, "stop")
+}
+
+func (a *App) handleNetworkRuntimeAction(w http.ResponseWriter, r *http.Request, action string) {
+	ctx, cancel := context.WithTimeout(r.Context(), 45*time.Second)
+	defer cancel()
+	if err := a.performNetworkRuntimeAction(ctx, action); err != nil {
+		a.setNetworkRuntimeLastError(err.Error())
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"success": false,
+			"error":   "network_runtime_" + action + "_failed",
+			"message": err.Error(),
+			"data":    a.networkRuntimeSnapshot(r.Context()),
+		})
+		return
+	}
+	a.setNetworkRuntimeLastError("")
+	if user := currentUser(r); user != nil {
+		a.audit(user, "network.runtime."+action, "network", "runtime", true, "")
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success": true,
+		"action":  action,
+		"data":    a.networkRuntimeSnapshot(r.Context()),
+	})
+}
+
+func (a *App) performNetworkRuntimeAction(ctx context.Context, action string) error {
+	a.networkRuntimeMu.Lock()
+	defer a.networkRuntimeMu.Unlock()
+
+	if !a.IsInitialized() {
+		return errors.New("MSF 尚未完成初始化，请先打开网页管理页完成设置")
+	}
+	cfg, ok := a.latestSetupConfig()
+	if !ok {
+		return errors.New("找不到已保存的 MSF 设置")
+	}
+	cfg.defaults()
+	if err := validateSetupProxyMode(cfg); err != nil {
+		return err
+	}
+	if IsMacOSRuntime() && !isTUNProxyMode(cfg.LinuxProxyMode) {
+		return errors.New("macOS 仅支持 TUN 模式")
+	}
+
+	switch action {
+	case "enable":
+		a.setNetworkTransition("starting")
+		defer a.setNetworkTransition("")
+		return a.enableNetworkRuntimeLocked(ctx, cfg, runtimeStateEnabled)
+	case "disable":
+		a.setNetworkTransition("")
+		return a.disableNetworkRuntimeLocked(ctx)
+	case "restart":
+		a.setNetworkTransition("restarting")
+		defer a.setNetworkTransition("")
+		return a.restartNetworkRuntimeLocked(ctx, cfg)
+	case "stop":
+		a.setNetworkTransition("")
+		return a.stopNetworkRuntimeLocked(ctx, cfg, true)
+	default:
+		return fmt.Errorf("unknown network runtime action %q", action)
+	}
+}
+
+func (a *App) enableNetworkRuntimeLocked(ctx context.Context, cfg SetupConfig, desired string) error {
+	started := make([]string, 0, 2)
+	for _, name := range managedServiceNames() {
+		shouldRun := name == "mihomo" || (name == "mosdns" && cfg.MosDNSEnabled)
+		if !shouldRun {
+			continue
+		}
+		wasRunning := a.Services.Status(name).Running
+		if _, err := a.Services.Start(ctx, name); err != nil {
+			a.stopNewlyStartedServices(ctx, started)
+			return fmt.Errorf("启动 %s: %w", name, err)
+		}
+		if !wasRunning {
+			started = append(started, name)
+		}
+	}
+	if err := applyPlatformNetwork(ctx, a, cfg); err != nil {
+		_ = restorePlatformNetwork(ctx, a, cfg)
+		a.stopNewlyStartedServices(ctx, started)
+		return err
+	}
+	mode := "rule"
+	if desired == runtimeStateDirect {
+		mode = "direct"
+	}
+	if err := a.setMihomoRuntimeMode(mode); err != nil {
+		_ = restorePlatformNetwork(ctx, a, cfg)
+		a.stopNewlyStartedServices(ctx, started)
+		return err
+	}
+	a.Services.setDesired("mihomo", true)
+	a.Services.setDesired("mosdns", cfg.MosDNSEnabled)
+	a.persistNetworkRuntimeDesired(desired)
+	return nil
+}
+
+func (a *App) disableNetworkRuntimeLocked(ctx context.Context) error {
+	if !a.Services.Status("mihomo").Running || !a.Services.Status("mosdns").Running {
+		return errors.New("数据面尚未完整运行，无法切换到 LAN 直连保活")
+	}
+	if err := a.setMihomoRuntimeMode("direct"); err != nil {
+		return err
+	}
+	a.persistNetworkRuntimeDesired(runtimeStateDirect)
+	return nil
+}
+
+func (a *App) restartNetworkRuntimeLocked(ctx context.Context, cfg SetupConfig) error {
+	desired := a.networkRuntimeDesired()
+	if desired == runtimeStateStopped {
+		desired = runtimeStateEnabled
+	}
+	var errs []error
+	for i := len(managedServiceNames()) - 1; i >= 0; i-- {
+		name := managedServiceNames()[i]
+		if _, err := a.Services.stop(ctx, name, false); err != nil {
+			errs = append(errs, fmt.Errorf("停止 %s: %w", name, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return a.enableNetworkRuntimeLocked(ctx, cfg, desired)
+}
+
+func (a *App) stopNetworkRuntimeLocked(ctx context.Context, cfg SetupConfig, persist bool) error {
+	var errs []error
+	if err := restorePlatformNetwork(ctx, a, cfg); err != nil {
+		errs = append(errs, err)
+	}
+	for i := len(managedServiceNames()) - 1; i >= 0; i-- {
+		name := managedServiceNames()[i]
+		if _, err := a.Services.stop(ctx, name, false); err != nil {
+			errs = append(errs, fmt.Errorf("停止 %s: %w", name, err))
+		}
+	}
+	if persist {
+		a.Services.setDesired("mihomo", false)
+		a.Services.setDesired("mosdns", false)
+		a.persistNetworkRuntimeDesired(runtimeStateStopped)
+	}
+	return errors.Join(errs...)
+}
+
+func (a *App) stopNewlyStartedServices(ctx context.Context, names []string) {
+	for i := len(names) - 1; i >= 0; i-- {
+		_, _ = a.Services.stop(ctx, names[i], false)
+	}
+}
+
+func (a *App) setMihomoRuntimeMode(mode string) error {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode != "rule" && mode != "direct" {
+		return fmt.Errorf("unsupported Mihomo runtime mode %q", mode)
+	}
+	body := []byte(fmt.Sprintf(`{"mode":%q}`, mode))
+	if _, ok, err := a.mihomoControllerJSON(http.MethodPatch, "/configs", body); !ok {
+		if err == nil {
+			err = errors.New("Mihomo controller unavailable")
+		}
+		return fmt.Errorf("切换 Mihomo 到 %s 模式: %w", mode, err)
+	}
+	return nil
+}
+
+func (a *App) networkRuntimeSnapshot(ctx context.Context) map[string]any {
+	mosdns := a.Services.Status("mosdns")
+	mihomo := a.Services.Status("mihomo")
+	desired := a.networkRuntimeDesired()
+	transition, lastError := a.networkRuntimeState()
+	effective := runtimeStateStopped
+	switch {
+	case transition != "":
+		effective = transition
+	case mosdns.Running && mihomo.Running && desired == runtimeStateDirect:
+		effective = runtimeStateDirect
+	case mosdns.Running && mihomo.Running:
+		effective = runtimeStateEnabled
+	case mosdns.Running || mihomo.Running:
+		effective = "degraded"
+	}
+	trafficRaw := a.mihomoTrafficCachedPayload()
+	traffic := map[string]any{
+		"down_bps": numericMapValue(trafficRaw, "down"),
+		"up_bps":   numericMapValue(trafficRaw, "up"),
+		"down":     numericMapValue(trafficRaw, "down"),
+		"up":       numericMapValue(trafficRaw, "up"),
+	}
+	message := ""
+	if !a.IsInitialized() {
+		message = "请先打开网页管理页完成初始化"
+	} else if lastError != "" {
+		message = lastError
+	} else if effective == runtimeStateDirect {
+		message = "TUN 与 DNS 保持运行，全部流量直连"
+	} else if effective == runtimeStateStopped {
+		message = "MosDNS、Mihomo 与系统网络接管均已停止"
+	}
+	return map[string]any{
+		"effective_state":       effective,
+		"state":                 effective,
+		"desired_state":         desired,
+		"supports_safe_disable": true,
+		"platform":              runtime.GOOS + "/" + runtime.GOARCH,
+		"initialized":           a.IsInitialized(),
+		"mosdns_running":        mosdns.Running,
+		"mihomo_running":        mihomo.Running,
+		"services": map[string]any{
+			"mosdns": mosdns,
+			"mihomo": mihomo,
+		},
+		"traffic":    traffic,
+		"network":    platformNetworkStatus(ctx, a),
+		"message":    message,
+		"last_error": lastError,
+		"updated_at": a.setting(networkRuntimeUpdatedKey, ""),
+	}
+}
+
+func (a *App) networkRuntimeDesired() string {
+	value := strings.ToLower(strings.TrimSpace(a.setting(networkRuntimeDesiredKey, "")))
+	switch value {
+	case runtimeStateEnabled, runtimeStateDirect, runtimeStateStopped:
+		return value
+	default:
+		if a.IsInitialized() {
+			return runtimeStateEnabled
+		}
+		return runtimeStateStopped
+	}
+}
+
+func (a *App) persistNetworkRuntimeDesired(value string) {
+	a.setSetting(networkRuntimeDesiredKey, value)
+	a.setSetting(networkRuntimeUpdatedKey, nowString())
+}
+
+func (a *App) setNetworkTransition(value string) {
+	a.networkStateMu.Lock()
+	a.networkTransition = value
+	a.networkStateMu.Unlock()
+}
+
+func (a *App) setNetworkRuntimeLastError(value string) {
+	a.networkStateMu.Lock()
+	a.networkLastError = value
+	a.networkStateMu.Unlock()
+}
+
+func (a *App) networkRuntimeState() (string, string) {
+	a.networkStateMu.RLock()
+	defer a.networkStateMu.RUnlock()
+	return a.networkTransition, a.networkLastError
+}

--- a/internal/server/network_runtime_platform.go
+++ b/internal/server/network_runtime_platform.go
@@ -1,0 +1,442 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+var (
+	applyPlatformNetwork   = defaultApplyPlatformNetwork
+	restorePlatformNetwork = defaultRestorePlatformNetwork
+	platformNetworkStatus  = defaultPlatformNetworkStatus
+	darwinNetworkCommand   = runDarwinNetworkCommand
+)
+
+type darwinDNSBackup struct {
+	Service   string   `json:"service"`
+	Device    string   `json:"device"`
+	Automatic bool     `json:"automatic"`
+	Servers   []string `json:"servers,omitempty"`
+}
+
+type darwinNetworkBackup struct {
+	Version           int               `json:"version"`
+	Applied           bool              `json:"applied"`
+	SelectedInterface string            `json:"selected_interface"`
+	RouteInterface    string            `json:"route_interface"`
+	IPv4Forwarding    string            `json:"ipv4_forwarding"`
+	DNS               []darwinDNSBackup `json:"dns"`
+	CapturedAt        string            `json:"captured_at"`
+}
+
+type darwinNetworkService struct {
+	Name     string
+	Device   string
+	Disabled bool
+}
+
+func defaultApplyPlatformNetwork(ctx context.Context, a *App, cfg SetupConfig) error {
+	if IsMacOSRuntime() {
+		return a.applyDarwinNetwork(ctx, cfg)
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if shouldRestoreNFT(cfg) {
+			_, err := a.applyNFT(ctx)
+			return err
+		}
+		if os.Geteuid() == 0 {
+			_, err := a.clearNFT(ctx)
+			return err
+		}
+	}
+	return nil
+}
+
+func defaultRestorePlatformNetwork(ctx context.Context, a *App, cfg SetupConfig) error {
+	if IsMacOSRuntime() {
+		return a.restoreDarwinNetwork(ctx)
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if os.Geteuid() == 0 {
+			_, err := a.clearNFT(ctx)
+			return err
+		}
+	}
+	return nil
+}
+
+func defaultPlatformNetworkStatus(ctx context.Context, a *App) map[string]any {
+	if IsMacOSRuntime() {
+		return a.darwinNetworkStatus(ctx)
+	}
+	switch runtime.GOOS {
+	case "linux":
+		return map[string]any{
+			"kind": "linux",
+			"nft":  a.nftStatus(),
+		}
+	default:
+		return map[string]any{"kind": runtime.GOOS, "supported": false}
+	}
+}
+
+func (a *App) applyDarwinNetwork(ctx context.Context, cfg SetupConfig) error {
+	if os.Geteuid() != 0 {
+		return errors.New("macOS TUN 后台必须以 root LaunchDaemon 运行")
+	}
+	cfg.defaults()
+	routeInterface, err := waitForDarwinFakeIPRoute(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	backup, err := a.readDarwinNetworkBackup()
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("读取 macOS 网络快照: %w", err)
+	}
+	if os.IsNotExist(err) || !backup.Applied {
+		backup, err = a.captureDarwinNetworkBackup(ctx, cfg, routeInterface)
+		if err != nil {
+			return err
+		}
+		if err := a.writeDarwinNetworkBackup(backup); err != nil {
+			return fmt.Errorf("保存 macOS 网络快照: %w", err)
+		}
+	}
+
+	if _, err := darwinNetworkCommand(ctx, "/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding=1"); err != nil {
+		_ = a.restoreDarwinNetwork(ctx)
+		return fmt.Errorf("启用 macOS IPv4 转发: %w", err)
+	}
+	for _, dns := range backup.DNS {
+		if _, err := darwinNetworkCommand(ctx, "/usr/sbin/networksetup", "-setdnsservers", dns.Service, "127.0.0.1"); err != nil {
+			_ = a.restoreDarwinNetwork(ctx)
+			return fmt.Errorf("设置 %s DNS: %w", dns.Service, err)
+		}
+	}
+	return nil
+}
+
+func (a *App) captureDarwinNetworkBackup(ctx context.Context, cfg SetupConfig, routeInterface string) (darwinNetworkBackup, error) {
+	services, err := listDarwinNetworkServices(ctx)
+	if err != nil {
+		return darwinNetworkBackup{}, err
+	}
+	selected := strings.TrimSpace(cfg.SelectedInterface)
+	defaultInterface, _ := darwinDefaultRouteInterface(ctx)
+	devices := uniqueStrings([]string{selected, defaultInterface})
+	backups := make([]darwinDNSBackup, 0, len(devices))
+	for _, device := range devices {
+		if device == "" {
+			continue
+		}
+		service, ok := darwinServiceForDevice(services, device)
+		if !ok {
+			continue
+		}
+		dns, err := getDarwinDNSBackup(ctx, service)
+		if err != nil {
+			return darwinNetworkBackup{}, err
+		}
+		backups = append(backups, dns)
+	}
+	if len(backups) == 0 {
+		return darwinNetworkBackup{}, fmt.Errorf("无法将网卡 %q 映射到 macOS 网络服务", firstNonEmpty(selected, defaultInterface))
+	}
+	forwarding, err := darwinNetworkCommand(ctx, "/usr/sbin/sysctl", "-n", "net.inet.ip.forwarding")
+	if err != nil {
+		return darwinNetworkBackup{}, fmt.Errorf("读取 macOS IPv4 转发状态: %w", err)
+	}
+	return darwinNetworkBackup{
+		Version:           1,
+		Applied:           true,
+		SelectedInterface: selected,
+		RouteInterface:    routeInterface,
+		IPv4Forwarding:    strings.TrimSpace(string(forwarding)),
+		DNS:               backups,
+		CapturedAt:        nowString(),
+	}, nil
+}
+
+func (a *App) restoreDarwinNetwork(ctx context.Context) error {
+	backup, err := a.readDarwinNetworkBackup()
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("读取 macOS 网络快照: %w", err)
+	}
+	var errs []error
+	for _, dns := range backup.DNS {
+		args := []string{"-setdnsservers", dns.Service}
+		if dns.Automatic || len(dns.Servers) == 0 {
+			args = append(args, "Empty")
+		} else {
+			args = append(args, dns.Servers...)
+		}
+		if _, err := darwinNetworkCommand(ctx, "/usr/sbin/networksetup", args...); err != nil {
+			errs = append(errs, fmt.Errorf("恢复 %s DNS: %w", dns.Service, err))
+		}
+	}
+	forwarding := strings.TrimSpace(backup.IPv4Forwarding)
+	if forwarding != "0" && forwarding != "1" {
+		forwarding = "0"
+	}
+	if _, err := darwinNetworkCommand(ctx, "/usr/sbin/sysctl", "-w", "net.inet.ip.forwarding="+forwarding); err != nil {
+		errs = append(errs, fmt.Errorf("恢复 macOS IPv4 转发: %w", err))
+	}
+	if len(errs) == 0 {
+		_ = os.Remove(a.darwinNetworkBackupPath())
+	}
+	return errors.Join(errs...)
+}
+
+func (a *App) darwinNetworkStatus(ctx context.Context) map[string]any {
+	status := map[string]any{
+		"kind":            "darwin-tun",
+		"supported":       true,
+		"is_root":         os.Geteuid() == 0,
+		"dns_applied":     false,
+		"ipv4_forwarding": false,
+		"route_ready":     false,
+	}
+	backup, err := a.readDarwinNetworkBackup()
+	if err == nil {
+		status["snapshot_present"] = true
+		status["selected_interface"] = backup.SelectedInterface
+		status["dns_services"] = backup.DNS
+		status["captured_at"] = backup.CapturedAt
+		applied := len(backup.DNS) > 0
+		for _, dns := range backup.DNS {
+			out, commandErr := darwinNetworkCommand(ctx, "/usr/sbin/networksetup", "-getdnsservers", dns.Service)
+			if commandErr != nil || !darwinDNSContainsLocalhost(string(out)) {
+				applied = false
+				break
+			}
+		}
+		status["dns_applied"] = applied
+	} else {
+		status["snapshot_present"] = false
+	}
+	if out, commandErr := darwinNetworkCommand(ctx, "/usr/sbin/sysctl", "-n", "net.inet.ip.forwarding"); commandErr == nil {
+		status["ipv4_forwarding"] = strings.TrimSpace(string(out)) == "1"
+	}
+	if cfg, ok := a.latestSetupConfig(); ok {
+		cfg.defaults()
+		if iface, commandErr := darwinFakeIPRouteInterface(ctx, cfg); commandErr == nil {
+			status["route_interface"] = iface
+			status["route_ready"] = strings.HasPrefix(iface, "utun")
+		}
+	}
+	status["ready"] = isTruthy(fmtAny(status["dns_applied"])) &&
+		isTruthy(fmtAny(status["route_ready"])) &&
+		isTruthy(fmtAny(status["ipv4_forwarding"]))
+	return status
+}
+
+func (a *App) darwinNetworkBackupPath() string {
+	return filepath.Join(a.DataDir, "configs/network/darwin-state.json")
+}
+
+func (a *App) readDarwinNetworkBackup() (darwinNetworkBackup, error) {
+	var backup darwinNetworkBackup
+	body, err := os.ReadFile(a.darwinNetworkBackupPath())
+	if err != nil {
+		return backup, err
+	}
+	if err := json.Unmarshal(body, &backup); err != nil {
+		return backup, err
+	}
+	return backup, nil
+}
+
+func (a *App) writeDarwinNetworkBackup(backup darwinNetworkBackup) error {
+	path := a.darwinNetworkBackupPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(backup, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".darwin-state-*.json")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func waitForDarwinFakeIPRoute(ctx context.Context, cfg SetupConfig) (string, error) {
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		iface, err := darwinFakeIPRouteInterface(ctx, cfg)
+		if err == nil && strings.HasPrefix(iface, "utun") {
+			return iface, nil
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return "", fmt.Errorf("等待 Mihomo TUN 路由: %w", err)
+			}
+			return "", fmt.Errorf("Fake-IP 路由未进入 utun，当前接口为 %q", iface)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+func darwinFakeIPRouteInterface(ctx context.Context, cfg SetupConfig) (string, error) {
+	prefix, err := netip.ParsePrefix(fakeIPv4RouteCIDR(cfg.FakeIPRangeV4))
+	if err != nil {
+		return "", err
+	}
+	probe := prefix.Masked().Addr().Next().String()
+	out, err := darwinNetworkCommand(ctx, "/sbin/route", "-n", "get", probe)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if ok && strings.TrimSpace(key) == "interface" {
+			return strings.TrimSpace(value), nil
+		}
+	}
+	return "", errors.New("route output does not contain an interface")
+}
+
+func darwinDefaultRouteInterface(ctx context.Context) (string, error) {
+	out, err := darwinNetworkCommand(ctx, "/sbin/route", "-n", "get", "default")
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if ok && strings.TrimSpace(key) == "interface" {
+			return strings.TrimSpace(value), nil
+		}
+	}
+	return "", errors.New("default route output does not contain an interface")
+}
+
+func listDarwinNetworkServices(ctx context.Context) ([]darwinNetworkService, error) {
+	out, err := darwinNetworkCommand(ctx, "/usr/sbin/networksetup", "-listnetworkserviceorder")
+	if err != nil {
+		return nil, fmt.Errorf("读取 macOS 网络服务: %w", err)
+	}
+	lines := strings.Split(string(out), "\n")
+	services := make([]darwinNetworkService, 0)
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		closeIndex := strings.Index(line, ") ")
+		if !strings.HasPrefix(line, "(") || closeIndex < 0 {
+			continue
+		}
+		name := strings.TrimSpace(line[closeIndex+2:])
+		disabled := strings.HasPrefix(name, "*")
+		name = strings.TrimSpace(strings.TrimPrefix(name, "*"))
+		if i+1 >= len(lines) {
+			continue
+		}
+		detail := strings.TrimSpace(lines[i+1])
+		deviceMarker := "Device:"
+		deviceIndex := strings.LastIndex(detail, deviceMarker)
+		if deviceIndex < 0 {
+			continue
+		}
+		device := strings.TrimSpace(strings.TrimSuffix(detail[deviceIndex+len(deviceMarker):], ")"))
+		services = append(services, darwinNetworkService{Name: name, Device: device, Disabled: disabled})
+		i++
+	}
+	return services, nil
+}
+
+func darwinServiceForDevice(services []darwinNetworkService, device string) (darwinNetworkService, bool) {
+	for _, service := range services {
+		if !service.Disabled && service.Device == device && service.Name != "" {
+			return service, true
+		}
+	}
+	return darwinNetworkService{}, false
+}
+
+func getDarwinDNSBackup(ctx context.Context, service darwinNetworkService) (darwinDNSBackup, error) {
+	out, err := darwinNetworkCommand(ctx, "/usr/sbin/networksetup", "-getdnsservers", service.Name)
+	if err != nil {
+		return darwinDNSBackup{}, fmt.Errorf("读取 %s DNS: %w", service.Name, err)
+	}
+	text := strings.TrimSpace(string(out))
+	backup := darwinDNSBackup{Service: service.Name, Device: service.Device}
+	if text == "" || strings.Contains(strings.ToLower(text), "aren't any dns servers") {
+		backup.Automatic = true
+		return backup, nil
+	}
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			backup.Servers = append(backup.Servers, line)
+		}
+	}
+	return backup, nil
+}
+
+func darwinDNSContainsLocalhost(text string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		if strings.TrimSpace(line) == "127.0.0.1" {
+			return true
+		}
+	}
+	return false
+}
+
+func runDarwinNetworkCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(commandCtx, name, args...).CombinedOutput()
+	if commandCtx.Err() != nil {
+		return out, commandCtx.Err()
+	}
+	if err != nil {
+		message := strings.TrimSpace(string(out))
+		if message != "" {
+			return out, fmt.Errorf("%s: %w", message, err)
+		}
+	}
+	return out, err
+}
+
+func sortedDarwinServiceNames(items []darwinNetworkService) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Name != "" {
+			names = append(names, item.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/server/network_runtime_test.go
+++ b/internal/server/network_runtime_test.go
@@ -1,0 +1,433 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNetworkRuntimeLifecycle(t *testing.T) {
+	t.Setenv("MSF_RUNTIME", "native")
+	app := newTestApp(t)
+	cfg := SetupConfig{
+		Username:          "root",
+		SelectedInterface: "en0",
+		LinuxProxyMode:    "tun",
+		ProxyCore:         "mihomo",
+		MosDNSEnabled:     true,
+	}
+	cfg.defaults()
+	if _, err := app.insertInitializedSetup(cfg); err != nil {
+		t.Fatal(err)
+	}
+	installRuntimeTestBinary(t, app, "mihomo")
+	installRuntimeTestBinary(t, app, "mosdns")
+
+	var modesMu sync.Mutex
+	var modes []string
+	controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/configs":
+			if r.Method == http.MethodPatch {
+				var body map[string]string
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				modesMu.Lock()
+				modes = append(modes, body["mode"])
+				modesMu.Unlock()
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"mode": "rule"})
+		case "/traffic":
+			_ = json.NewEncoder(w).Encode(map[string]any{"up": 1024, "down": 4096})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(controller.Close)
+	app.setSetting("mihomo_controller_endpoint", controller.URL)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = app.Services.StopAll(ctx)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := app.performNetworkRuntimeAction(ctx, "enable"); err != nil {
+		t.Fatalf("enable runtime: %v", err)
+	}
+	if !app.Services.Status("mihomo").Running || !app.Services.Status("mosdns").Running {
+		t.Fatalf("enable should start both services: %#v", app.Services.List())
+	}
+	if got := app.networkRuntimeDesired(); got != runtimeStateEnabled {
+		t.Fatalf("desired state after enable = %q, want %q", got, runtimeStateEnabled)
+	}
+	if got := app.networkRuntimeSnapshot(ctx)["effective_state"]; got != runtimeStateEnabled {
+		t.Fatalf("effective state after enable = %#v, want %q", got, runtimeStateEnabled)
+	}
+
+	if err := app.performNetworkRuntimeAction(ctx, "disable"); err != nil {
+		t.Fatalf("safe disable runtime: %v", err)
+	}
+	if !app.Services.Status("mihomo").Running || !app.Services.Status("mosdns").Running {
+		t.Fatal("safe disable must keep Mihomo and MosDNS running")
+	}
+	if got := app.networkRuntimeDesired(); got != runtimeStateDirect {
+		t.Fatalf("desired state after safe disable = %q, want %q", got, runtimeStateDirect)
+	}
+
+	if err := app.performNetworkRuntimeAction(ctx, "restart"); err != nil {
+		t.Fatalf("restart runtime: %v", err)
+	}
+	if !app.Services.Status("mihomo").Running || !app.Services.Status("mosdns").Running {
+		t.Fatal("restart should leave both services running")
+	}
+	if got := app.networkRuntimeDesired(); got != runtimeStateDirect {
+		t.Fatalf("restart should preserve direct desired state, got %q", got)
+	}
+
+	if err := app.performNetworkRuntimeAction(ctx, "stop"); err != nil {
+		t.Fatalf("full stop runtime: %v", err)
+	}
+	if app.Services.Status("mihomo").Running || app.Services.Status("mosdns").Running {
+		t.Fatalf("full stop should stop both services: %#v", app.Services.List())
+	}
+	if got := app.networkRuntimeDesired(); got != runtimeStateStopped {
+		t.Fatalf("desired state after full stop = %q, want %q", got, runtimeStateStopped)
+	}
+
+	modesMu.Lock()
+	gotModes := strings.Join(modes, ",")
+	modesMu.Unlock()
+	if gotModes != "rule,direct,direct" {
+		t.Fatalf("Mihomo runtime mode changes = %q, want rule,direct,direct", gotModes)
+	}
+}
+
+func TestNetworkRuntimeRequiresInitializationAndAuthorization(t *testing.T) {
+	app := newTestApp(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := app.performNetworkRuntimeAction(ctx, "enable"); err == nil || !strings.Contains(err.Error(), "尚未完成初始化") {
+		t.Fatalf("uninitialized enable error = %v", err)
+	}
+
+	viewer := tokenForRole(t, app, "viewer")
+	if res := requestJSON(t, app, http.MethodGet, "/api/v1/network/runtime", viewer, nil); res.Code != http.StatusOK {
+		t.Fatalf("viewer should read runtime state: status=%d body=%s", res.Code, res.Body.String())
+	}
+	if res := requestJSON(t, app, http.MethodPost, "/api/v1/network/runtime/enable", viewer, nil); res.Code != http.StatusForbidden {
+		t.Fatalf("viewer should not mutate runtime state: status=%d body=%s", res.Code, res.Body.String())
+	}
+	operator := tokenForRole(t, app, "operator")
+	if res := requestJSON(t, app, http.MethodPost, "/api/v1/network/runtime/enable", operator, nil); res.Code != http.StatusConflict {
+		t.Fatalf("operator should reach runtime action handler: status=%d body=%s", res.Code, res.Body.String())
+	}
+}
+
+func TestDarwinNetworkCommandParsing(t *testing.T) {
+	oldCommand := darwinNetworkCommand
+	t.Cleanup(func() { darwinNetworkCommand = oldCommand })
+	darwinNetworkCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		command := name + " " + strings.Join(args, " ")
+		switch command {
+		case "/usr/sbin/networksetup -listnetworkserviceorder":
+			return []byte(`An asterisk (*) denotes that a network service is disabled.
+(1) Wi-Fi
+(Hardware Port: Wi-Fi, Device: en0)
+(2) *Thunderbolt Bridge
+(Hardware Port: Thunderbolt Bridge, Device: bridge0)
+(3) USB 10/100/1000 LAN
+(Hardware Port: USB 10/100/1000 LAN, Device: en5)
+`), nil
+		case "/usr/sbin/networksetup -getdnsservers Wi-Fi":
+			return []byte("There aren't any DNS Servers set on Wi-Fi.\n"), nil
+		case "/usr/sbin/networksetup -getdnsservers USB 10/100/1000 LAN":
+			return []byte("1.1.1.1\n8.8.8.8\n"), nil
+		case "/sbin/route -n get default":
+			return []byte("   route to: default\ninterface: en0\n"), nil
+		case "/sbin/route -n get 28.0.0.1":
+			return []byte("   route to: 28.0.0.1\ninterface: utun7\n"), nil
+		default:
+			t.Fatalf("unexpected Darwin command: %s", command)
+			return nil, nil
+		}
+	}
+
+	services, err := listDarwinNetworkServices(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(sortedDarwinServiceNames(services), ","); got != "Thunderbolt Bridge,USB 10/100/1000 LAN,Wi-Fi" {
+		t.Fatalf("parsed network services = %q", got)
+	}
+	if service, ok := darwinServiceForDevice(services, "en0"); !ok || service.Name != "Wi-Fi" {
+		t.Fatalf("en0 service mapping = %#v, %v", service, ok)
+	}
+	if _, ok := darwinServiceForDevice(services, "bridge0"); ok {
+		t.Fatal("disabled network service must not be selected")
+	}
+
+	wifiDNS, err := getDarwinDNSBackup(context.Background(), darwinNetworkService{Name: "Wi-Fi", Device: "en0"})
+	if err != nil || !wifiDNS.Automatic || len(wifiDNS.Servers) != 0 {
+		t.Fatalf("automatic Wi-Fi DNS backup = %#v, err=%v", wifiDNS, err)
+	}
+	usbDNS, err := getDarwinDNSBackup(context.Background(), darwinNetworkService{Name: "USB 10/100/1000 LAN", Device: "en5"})
+	if err != nil || usbDNS.Automatic || strings.Join(usbDNS.Servers, ",") != "1.1.1.1,8.8.8.8" {
+		t.Fatalf("explicit USB DNS backup = %#v, err=%v", usbDNS, err)
+	}
+	if iface, err := darwinDefaultRouteInterface(context.Background()); err != nil || iface != "en0" {
+		t.Fatalf("default route interface = %q, err=%v", iface, err)
+	}
+	cfg := SetupConfig{FakeIPRangeV4: "28.0.0.0/8"}
+	if iface, err := darwinFakeIPRouteInterface(context.Background(), cfg); err != nil || iface != "utun7" {
+		t.Fatalf("Fake-IP route interface = %q, err=%v", iface, err)
+	}
+	if !darwinDNSContainsLocalhost("192.168.1.1\n127.0.0.1\n") || darwinDNSContainsLocalhost("127.0.0.53\n") {
+		t.Fatal("localhost DNS matching is incorrect")
+	}
+}
+
+func TestChooseDarwinSetupInterfaceSkipsVirtualDefaultRoute(t *testing.T) {
+	services := []darwinNetworkService{
+		{Name: "Ethernet", Device: "en0"},
+		{Name: "Wi-Fi", Device: "en1"},
+		{Name: "Disabled LAN", Device: "en8", Disabled: true},
+	}
+	usable := map[string]bool{"en0": true, "en1": true, "utun5": true}
+	check := func(name string) bool { return usable[name] }
+
+	if got := chooseDarwinSetupInterface("utun5", services, check); got != "en0" {
+		t.Fatalf("virtual default route selected %q, want first usable physical service en0", got)
+	}
+	if got := chooseDarwinSetupInterface("en1", services, check); got != "en1" {
+		t.Fatalf("physical default route selected %q, want en1", got)
+	}
+	usable["en0"] = false
+	if got := chooseDarwinSetupInterface("utun5", services, check); got != "en1" {
+		t.Fatalf("fallback selected %q, want next usable physical service en1", got)
+	}
+}
+
+func TestMacOSTunConfigLetsMihomoAllocateUtun(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS runtime detection requires a Darwin build")
+	}
+	cfg := SetupConfig{LinuxProxyMode: "tun", FakeIPRangeV4: "28.0.0.0/8"}
+
+	t.Setenv("MSF_RUNTIME", "native")
+	nativeYAML := renderMihomoTunYAML(cfg)
+	if !strings.Contains(nativeYAML, "  device: mihomo\n") {
+		t.Fatalf("native TUN config should retain the named device:\n%s", nativeYAML)
+	}
+
+	t.Setenv("MSF_RUNTIME", "macos")
+	macOSYAML := renderMihomoTunYAML(cfg)
+	if strings.Contains(macOSYAML, "device:") {
+		t.Fatalf("macOS TUN config must let Mihomo allocate an available utun:\n%s", macOSYAML)
+	}
+	for _, want := range []string{"stack: system", "auto-route: true", "route-address:", "- 28.0.0.0/8"} {
+		if !strings.Contains(macOSYAML, want) {
+			t.Fatalf("macOS TUN config missing %q:\n%s", want, macOSYAML)
+		}
+	}
+}
+
+func TestMacOSCompatibilityMigrationForcesTunAndAutomaticDNS(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS runtime detection requires a Darwin build")
+	}
+	t.Setenv("MSF_RUNTIME", "native")
+	app := newTestApp(t)
+	cfg := SetupConfig{
+		Username:          "root",
+		SelectedInterface: "msf-invalid-interface",
+		LinuxProxyMode:    "nft",
+		AutoSetDNS:        false,
+		ProxyCore:         "mihomo",
+		MosDNSEnabled:     true,
+	}
+	cfg.defaults()
+	if _, err := app.insertInitializedSetup(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("MSF_RUNTIME", "macos")
+	if shouldRestoreNFT(cfg) {
+		t.Fatal("macOS must never restore nftables state")
+	}
+	migrated, err := app.migrateSetupProxyModeForRuntime(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !migrated {
+		t.Fatal("legacy macOS configuration should be reported as migrated")
+	}
+	if cfg.LinuxProxyMode != "tun" || !cfg.AutoSetDNS || cfg.SelectedInterface == "" || cfg.SelectedInterface == "msf-invalid-interface" {
+		t.Fatalf("effective macOS config=%#v, want TUN with automatic DNS", cfg)
+	}
+	stored, ok := app.latestSetupConfig()
+	if !ok || stored.LinuxProxyMode != "tun" || !stored.AutoSetDNS || stored.SelectedInterface != cfg.SelectedInterface {
+		t.Fatalf("stored macOS config=%#v ok=%t, want TUN with automatic DNS", stored, ok)
+	}
+}
+
+func TestRestoreConfiguredRuntimePersistsMacOSAutomaticDNSMigration(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS runtime detection requires a Darwin build")
+	}
+	t.Setenv("MSF_RUNTIME", "native")
+	app := newTestApp(t)
+	selectedInterface := defaultSetupInterface()
+	if selectedInterface == "" {
+		t.Skip("test host does not expose a usable network interface")
+	}
+	cfg := SetupConfig{
+		Username:          "root",
+		SelectedInterface: selectedInterface,
+		LinuxProxyMode:    "tun",
+		AutoSetDNS:        false,
+		ProxyCore:         "mihomo",
+		MosDNSEnabled:     true,
+	}
+	cfg.defaults()
+	if _, err := app.insertInitializedSetup(cfg); err != nil {
+		t.Fatal(err)
+	}
+	app.setMihomoConfigMode("generated")
+	if err := app.writeGeneratedConfigs(cfg); err != nil {
+		t.Fatal(err)
+	}
+	app.persistNetworkRuntimeDesired(runtimeStateStopped)
+
+	t.Setenv("MSF_RUNTIME", "macos")
+	report := app.RestoreConfiguredRuntime(context.Background())
+	if len(report.Errors) > 0 {
+		t.Fatalf("restore errors=%v", report.Errors)
+	}
+	stored, ok := app.latestSetupConfig()
+	if !ok || !stored.AutoSetDNS {
+		t.Fatalf("stored macOS config=%#v ok=%t, want automatic DNS persisted", stored, ok)
+	}
+}
+
+func TestDarwinNetworkStatusRequiresDNSRouteAndForwarding(t *testing.T) {
+	t.Setenv("MSF_RUNTIME", "native")
+	app := newTestApp(t)
+	cfg := SetupConfig{
+		Username:          "root",
+		SelectedInterface: "en0",
+		LinuxProxyMode:    "tun",
+		ProxyCore:         "mihomo",
+		MosDNSEnabled:     true,
+	}
+	cfg.defaults()
+	if _, err := app.insertInitializedSetup(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.writeDarwinNetworkBackup(darwinNetworkBackup{
+		Version:           1,
+		Applied:           true,
+		SelectedInterface: "en0",
+		IPv4Forwarding:    "0",
+		DNS:               []darwinDNSBackup{{Service: "Wi-Fi", Device: "en0", Automatic: true}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCommand := darwinNetworkCommand
+	t.Cleanup(func() { darwinNetworkCommand = oldCommand })
+	forwarding := "0"
+	darwinNetworkCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		command := name + " " + strings.Join(args, " ")
+		switch command {
+		case "/usr/sbin/networksetup -getdnsservers Wi-Fi":
+			return []byte("127.0.0.1\n"), nil
+		case "/usr/sbin/sysctl -n net.inet.ip.forwarding":
+			return []byte(forwarding + "\n"), nil
+		case "/sbin/route -n get 28.0.0.1":
+			return []byte("route to: 28.0.0.1\ninterface: utun9\n"), nil
+		default:
+			t.Fatalf("unexpected Darwin status command: %s", command)
+			return nil, nil
+		}
+	}
+
+	status := app.darwinNetworkStatus(context.Background())
+	if isTruthy(fmtAny(status["ready"])) {
+		t.Fatalf("status must not be ready while forwarding is disabled: %#v", status)
+	}
+	forwarding = "1"
+	status = app.darwinNetworkStatus(context.Background())
+	if !isTruthy(fmtAny(status["ready"])) {
+		t.Fatalf("status should be ready when DNS, utun route and forwarding are active: %#v", status)
+	}
+}
+
+func TestRestoreDarwinNetworkPreservesCapturedForwardingAndDNS(t *testing.T) {
+	app := newTestApp(t)
+	backup := darwinNetworkBackup{
+		Version:        1,
+		Applied:        true,
+		IPv4Forwarding: "1",
+		DNS: []darwinDNSBackup{
+			{Service: "Wi-Fi", Device: "en0", Automatic: true},
+			{Service: "Ethernet", Device: "en5", Servers: []string{"1.1.1.1", "8.8.8.8"}},
+		},
+	}
+	if err := app.writeDarwinNetworkBackup(backup); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(app.darwinNetworkBackupPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("Darwin network backup permissions = %o, want 600", got)
+	}
+
+	oldCommand := darwinNetworkCommand
+	t.Cleanup(func() { darwinNetworkCommand = oldCommand })
+	var commands []string
+	darwinNetworkCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		return nil, nil
+	}
+	if err := app.restoreDarwinNetwork(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"/usr/sbin/networksetup -setdnsservers Wi-Fi Empty",
+		"/usr/sbin/networksetup -setdnsservers Ethernet 1.1.1.1 8.8.8.8",
+		"/usr/sbin/sysctl -w net.inet.ip.forwarding=1",
+	}
+	if strings.Join(commands, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("restore commands:\n%s\nwant:\n%s", strings.Join(commands, "\n"), strings.Join(want, "\n"))
+	}
+	if _, err := os.Stat(app.darwinNetworkBackupPath()); !os.IsNotExist(err) {
+		t.Fatalf("successful restore should remove backup, stat err=%v", err)
+	}
+}
+
+func installRuntimeTestBinary(t *testing.T, app *App, component string) {
+	t.Helper()
+	path := filepath.Join(app.DataDir, "data/binaries", component, component)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\ntrap 'exit 0' TERM INT\nwhile :; do sleep 1; done\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -24,20 +24,20 @@ type ServiceManager struct {
 }
 
 type ServiceStatus struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"display_name"`
-	Installed   bool   `json:"installed"`
-	Running     bool   `json:"running"`
-	PID         int    `json:"pid,omitempty"`
-	Status      string `json:"status"`
-	Version     string `json:"version,omitempty"`
-	Uptime      int64  `json:"uptime,omitempty"`
-	Memory      int64  `json:"memory,omitempty"`
-	CPU         int64  `json:"cpu,omitempty"`
-	BinaryPath  string `json:"binary_path,omitempty"`
-	ConfigPath  string `json:"config_path,omitempty"`
-	LogPath     string `json:"log_path,omitempty"`
-	Error       string `json:"error,omitempty"`
+	Name        string  `json:"name"`
+	DisplayName string  `json:"display_name"`
+	Installed   bool    `json:"installed"`
+	Running     bool    `json:"running"`
+	PID         int     `json:"pid,omitempty"`
+	Status      string  `json:"status"`
+	Version     string  `json:"version,omitempty"`
+	Uptime      int64   `json:"uptime,omitempty"`
+	Memory      int64   `json:"memory,omitempty"`
+	CPU         float64 `json:"cpu,omitempty"`
+	BinaryPath  string  `json:"binary_path,omitempty"`
+	ConfigPath  string  `json:"config_path,omitempty"`
+	LogPath     string  `json:"log_path,omitempty"`
+	Error       string  `json:"error,omitempty"`
 }
 
 func NewServiceManager(app *App) *ServiceManager {
@@ -124,18 +124,34 @@ func (sm *ServiceManager) Start(ctx context.Context, name string) (ServiceStatus
 	}
 	sm.procs[name] = cmd
 	_ = os.WriteFile(spec.PIDFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0644)
+	waitDone := make(chan struct{})
 	go func() {
 		_ = cmd.Wait()
 		stdout.Close()
 		stderr.Close()
 		_ = os.Remove(spec.PIDFile)
+		close(waitDone)
 		sm.mu.Lock()
 		delete(sm.procs, name)
 		sm.mu.Unlock()
 	}()
-	time.Sleep(300 * time.Millisecond)
+	timer := time.NewTimer(300 * time.Millisecond)
+	exitedDuringStartup := false
+	select {
+	case <-waitDone:
+		exitedDuringStartup = true
+		if !timer.Stop() {
+			<-timer.C
+		}
+	case <-timer.C:
+		select {
+		case <-waitDone:
+			exitedDuringStartup = true
+		default:
+		}
+	}
 	st := sm.Status(name)
-	if st.Running {
+	if !exitedDuringStartup && st.Running {
 		sm.setDesired(name, true)
 		sm.app.afterServiceStart(name)
 		return st, nil

--- a/internal/server/proxy_mode_consistency.go
+++ b/internal/server/proxy_mode_consistency.go
@@ -14,6 +14,9 @@ func validateSetupProxyMode(cfg SetupConfig) error {
 	if IsDockerRuntime() && !isTUNProxyMode(cfg.LinuxProxyMode) {
 		return fmt.Errorf("Docker runtime only supports linux_proxy_mode=tun")
 	}
+	if IsMacOSRuntime() && !isTUNProxyMode(cfg.LinuxProxyMode) {
+		return fmt.Errorf("macOS only supports linux_proxy_mode=tun")
+	}
 	if !isTUNProxyMode(cfg.LinuxProxyMode) && !isNFTProxyMode(cfg.LinuxProxyMode) {
 		return fmt.Errorf("unsupported linux_proxy_mode %q", cfg.LinuxProxyMode)
 	}

--- a/internal/server/proxy_mode_consistency_test.go
+++ b/internal/server/proxy_mode_consistency_test.go
@@ -86,8 +86,12 @@ func TestDockerCompatibilityMigrationForcesDatabaseTargetToTun(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("MSF_RUNTIME", "docker")
-	if err := app.migrateSetupProxyModeForRuntime(&cfg); err != nil {
+	migrated, err := app.migrateSetupProxyModeForRuntime(&cfg)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !migrated {
+		t.Fatal("Docker nft configuration should be reported as migrated")
 	}
 	if cfg.LinuxProxyMode != "tun" {
 		t.Fatalf("effective Docker mode=%q, want tun", cfg.LinuxProxyMode)

--- a/internal/server/runtime.go
+++ b/internal/server/runtime.go
@@ -22,9 +22,14 @@ func (a *App) SetConfiguredRuntimeDesired(cfg SetupConfig) {
 	a.Services.setDesired("mihomo", strings.EqualFold(cfg.ProxyCore, "mihomo"))
 	a.Services.setDesired("mosdns", cfg.MosDNSEnabled)
 	a.setSetting(nftDesiredKey, boolSetting(shouldRestoreNFT(cfg)))
+	if a.setting(networkRuntimeDesiredKey, "") == "" {
+		a.persistNetworkRuntimeDesired(runtimeStateEnabled)
+	}
 }
 
 func (a *App) RestoreConfiguredRuntime(ctx context.Context) RuntimeRestoreReport {
+	a.networkRuntimeMu.Lock()
+	defer a.networkRuntimeMu.Unlock()
 	if a.resetInProgress.Load() {
 		return RuntimeRestoreReport{Errors: []string{"system factory reset is in progress"}}
 	}
@@ -42,10 +47,16 @@ func (a *App) RestoreConfiguredRuntime(ctx context.Context) RuntimeRestoreReport
 		report.Errors = append(report.Errors, "initialized setup config is missing")
 		return report
 	}
-	cfg.defaults()
-	if err := a.migrateSetupProxyModeForRuntime(&cfg); err != nil {
+	migrated, err := a.migrateSetupProxyModeForRuntime(&cfg)
+	if err != nil {
 		report.Errors = append(report.Errors, err.Error())
 		return report
+	}
+	if migrated && a.mihomoConfigMode() != "custom" {
+		if err := a.writeGeneratedConfigs(cfg); err != nil {
+			report.Errors = append(report.Errors, "failed to regenerate migrated runtime config: "+err.Error())
+			return report
+		}
 	}
 	if err := validateSetupProxyMode(cfg); err != nil {
 		report.Errors = append(report.Errors, err.Error())
@@ -77,37 +88,67 @@ func (a *App) RestoreConfiguredRuntime(ctx context.Context) RuntimeRestoreReport
 		report.Errors = append(report.Errors, err.Error())
 		return report
 	}
+	desired := a.networkRuntimeDesired()
+	if desired == runtimeStateStopped {
+		if err := restorePlatformNetwork(ctx, a, cfg); err != nil {
+			report.Errors = append(report.Errors, "failed to restore platform network: "+err.Error())
+		}
+		report.Services = a.Services.List()
+		return report
+	}
 	report.Errors = append(report.Errors, a.Services.StartEnabled(ctx)...)
 	report.Services = a.Services.List()
-	if a.setting(nftDesiredKey, "") == "true" {
-		output, err := a.applyNFT(ctx)
-		status := a.nftStatus()
-		if output != "" {
-			status["output"] = output
+	if err := applyPlatformNetwork(ctx, a, cfg); err != nil {
+		msg := "failed to restore platform network: " + err.Error()
+		report.Errors = append(report.Errors, msg)
+		log.Print(msg)
+	} else {
+		mode := "rule"
+		if desired == runtimeStateDirect {
+			mode = "direct"
 		}
-		report.NFT = status
-		if err != nil {
-			msg := "failed to restore nftables: " + err.Error()
-			report.Errors = append(report.Errors, msg)
-			log.Print(msg)
+		if err := a.setMihomoRuntimeMode(mode); err != nil {
+			report.Errors = append(report.Errors, err.Error())
 		}
+	}
+	if runtime.GOOS == "linux" {
+		report.NFT = a.nftStatus()
 	}
 	return report
 }
 
-func (a *App) migrateSetupProxyModeForRuntime(cfg *SetupConfig) error {
+func (a *App) migrateSetupProxyModeForRuntime(cfg *SetupConfig) (bool, error) {
 	if cfg == nil {
-		return nil
+		return false, nil
 	}
+	storedMode := strings.TrimSpace(cfg.LinuxProxyMode)
+	storedAutoSetDNS := cfg.AutoSetDNS
+	storedInterface := strings.TrimSpace(cfg.SelectedInterface)
 	cfg.defaults()
-	if !IsDockerRuntime() || isTUNProxyMode(cfg.LinuxProxyMode) {
-		return nil
+	isDocker := IsDockerRuntime()
+	isMacOS := IsMacOSRuntime()
+	if !isDocker && !isMacOS {
+		return false, nil
 	}
 	cfg.LinuxProxyMode = "tun"
-	if _, err := a.DB.Exec(`update system_setups set linux_proxy_mode='tun',updated_at=? where id=(select id from system_setups order by id desc limit 1)`, nowString()); err != nil {
-		return fmt.Errorf("failed to migrate Docker proxy mode to TUN: %w", err)
+	if isMacOS {
+		cfg.AutoSetDNS = true
+		normalizeSetupInterfaceForRuntime(cfg)
 	}
-	return nil
+	modeChanged := !isTUNProxyMode(storedMode)
+	dnsChanged := isMacOS && !storedAutoSetDNS
+	interfaceChanged := isMacOS && strings.TrimSpace(cfg.SelectedInterface) != storedInterface
+	if !modeChanged && !dnsChanged && !interfaceChanged {
+		return false, nil
+	}
+	if _, err := a.DB.Exec(`update system_setups set linux_proxy_mode='tun',auto_set_dns=?,selected_interface=?,updated_at=? where id=(select id from system_setups order by id desc limit 1)`, cfg.AutoSetDNS, cfg.SelectedInterface, nowString()); err != nil {
+		platform := "Docker"
+		if isMacOS {
+			platform = "macOS"
+		}
+		return false, fmt.Errorf("failed to migrate %s network settings to TUN: %w", platform, err)
+	}
+	return true, nil
 }
 
 func (a *App) backfillConfiguredRuntimeDesired() {
@@ -135,7 +176,7 @@ func (a *App) latestSetupConfig() (SetupConfig, bool) {
 }
 
 func shouldRestoreNFT(cfg SetupConfig) bool {
-	return !IsDockerRuntime() && isNFTProxyMode(cfg.LinuxProxyMode)
+	return !IsDockerRuntime() && !IsMacOSRuntime() && isNFTProxyMode(cfg.LinuxProxyMode)
 }
 
 func (a *App) currentLinuxProxyMode() string {

--- a/internal/server/runtime_env.go
+++ b/internal/server/runtime_env.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"errors"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -31,6 +33,18 @@ func IsDockerRuntime() bool {
 		}
 	}
 	return false
+}
+
+func IsMacOSRuntime() bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("MSF_RUNTIME"))) {
+	case "macos", "darwin", "macos-daemon":
+		return true
+	default:
+		return false
+	}
 }
 
 func DockerCleanupNetworkOnExit() bool {
@@ -74,13 +88,23 @@ func FnOSUpdateDisabledReason() string {
 }
 
 func (a *App) ShutdownRuntime(ctx context.Context) error {
-	err := a.Services.StopAll(ctx)
+	a.networkRuntimeMu.Lock()
+	defer a.networkRuntimeMu.Unlock()
+	var errs []error
+	cfg, _ := a.latestSetupConfig()
+	cfg.defaults()
+	if err := restorePlatformNetwork(ctx, a, cfg); err != nil {
+		errs = append(errs, err)
+	}
+	if err := a.Services.StopAll(ctx); err != nil {
+		errs = append(errs, err)
+	}
 	if IsDockerRuntime() && DockerCleanupNetworkOnExit() && a.shouldCleanupDockerNetwork() {
-		if _, clearErr := a.clearNFT(ctx); clearErr != nil && err == nil {
-			err = clearErr
+		if _, clearErr := a.clearNFT(ctx); clearErr != nil {
+			errs = append(errs, clearErr)
 		}
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 func (a *App) shouldCleanupDockerNetwork() bool {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -221,6 +221,36 @@ func TestComponentDownloadURLForRuntimeArch(t *testing.T) {
 			wantSubstring: "mosdns-linux-arm64.zip",
 		},
 		{
+			name:          "mihomo darwin arm64",
+			component:     "mihomo",
+			goos:          "darwin",
+			goarch:        "arm64",
+			mihomoCore:    "meta",
+			wantSubstring: "mihomo-darwin-arm64.gz",
+		},
+		{
+			name:          "mihomo darwin amd64 compatible",
+			component:     "mihomo",
+			goos:          "darwin",
+			goarch:        "amd64",
+			mihomoCore:    "meta",
+			wantSubstring: "mihomo-darwin-amd64-compatible.gz",
+		},
+		{
+			name:          "mosdns darwin arm64",
+			component:     "mosdns",
+			goos:          "darwin",
+			goarch:        "arm64",
+			wantSubstring: "baozaodetudou/mssb/releases/download/mosdns/mosdns-darwin-arm64.zip",
+		},
+		{
+			name:          "mosdns darwin amd64",
+			component:     "mosdns",
+			goos:          "darwin",
+			goarch:        "amd64",
+			wantSubstring: "baozaodetudou/mssb/releases/download/mosdns/mosdns-darwin-amd64.zip",
+		},
+		{
 			name:          "zashboard is architecture independent",
 			component:     "zashboard",
 			goos:          "linux",
@@ -1290,6 +1320,9 @@ func TestMosDNSMSFCompatRuleAndSystemEndpoints(t *testing.T) {
 func TestMosDNSClientScanMSFCompatShape(t *testing.T) {
 	app := newTestApp(t)
 	token := tokenForRole(t, app, "admin")
+	api := httptest.NewServer(http.NotFoundHandler())
+	defer api.Close()
+	app.setSetting("mosdns_api_endpoint", api.URL)
 	now := time.Now()
 	if err := os.MkdirAll(filepath.Join(app.DataDir, "logs"), 0755); err != nil {
 		t.Fatal(err)

--- a/internal/server/setup_preflight.go
+++ b/internal/server/setup_preflight.go
@@ -91,7 +91,7 @@ var (
 	setupGeteuid         = os.Geteuid
 	setupProbePort       = probeSetupPort
 	setupShouldProbePort = func() bool {
-		return runtime.GOOS == "linux" && setupGeteuid() == 0
+		return (runtime.GOOS == "linux" || IsMacOSRuntime()) && setupGeteuid() == 0
 	}
 	setupTunPreflight        = detectSetupTUN
 	setupTUNDeviceStat       = os.Stat
@@ -137,9 +137,9 @@ func (a *App) buildSetupPreflight(ctx context.Context, targetTimezone string, au
 		result.Blocking = true
 		result.Errors = append(result.Errors, result.Timezone.Message)
 	}
-	if runtime.GOOS == "linux" && setupGeteuid() != 0 {
+	if (runtime.GOOS == "linux" || IsMacOSRuntime()) && setupGeteuid() != 0 {
 		result.Blocking = true
-		result.Errors = append(result.Errors, "MosDNS 53 端口和 TUN/nftables 需要 root 权限")
+		result.Errors = append(result.Errors, "MosDNS 53 端口和 TUN 需要 root 权限")
 	}
 
 	listeners := collectSetupPortListeners(ctx, setupAllCheckedPorts(proxyMode))
@@ -169,6 +169,18 @@ func detectSetupTUN(proxyMode string) setupTUNStatus {
 	status := setupTUNStatus{Required: isTUNProxyMode(proxyMode), Available: true, Device: "/dev/net/tun", NetAdmin: true, NetRaw: true}
 	if !status.Required {
 		status.Message = "TUN device is not required for nftables mode"
+		return status
+	}
+	if IsMacOSRuntime() {
+		status.Device = "utun"
+		status.NetAdmin = setupGeteuid() == 0
+		status.NetRaw = setupGeteuid() == 0
+		if setupGeteuid() != 0 {
+			status.Available = false
+			status.Message = "macOS TUN 模式需要 root LaunchDaemon"
+			return status
+		}
+		status.Message = "macOS utun and root privileges are available"
 		return status
 	}
 	if runtime.GOOS != "linux" {

--- a/internal/server/system_metrics.go
+++ b/internal/server/system_metrics.go
@@ -2,14 +2,18 @@ package server
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"math"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -17,7 +21,7 @@ import (
 type procMetrics struct {
 	Uptime int64
 	Memory int64
-	CPU    int64
+	CPU    float64
 }
 
 type cpuTimes struct {
@@ -26,7 +30,13 @@ type cpuTimes struct {
 }
 
 func processResourceSnapshot(pid int) (procMetrics, bool) {
-	if runtime.GOOS != "linux" || pid <= 0 {
+	if pid <= 0 {
+		return procMetrics{}, false
+	}
+	if runtime.GOOS == "darwin" {
+		return processResourceSnapshotDarwin(pid)
+	}
+	if runtime.GOOS != "linux" {
 		return procMetrics{}, false
 	}
 	stat, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
@@ -53,9 +63,83 @@ func processResourceSnapshot(pid int) (procMetrics, bool) {
 		elapsed = 1
 	}
 	cpuSeconds := float64(utime+stime) / clockTicks
-	cpuPercent := int64(math.Round(normalizeProcessCPUPercent(cpuSeconds * 100 / elapsed)))
+	cpuPercent := roundMetric(normalizeProcessCPUPercent(cpuSeconds*100/elapsed), 1)
 	rss := readProcRSSBytes(pid)
 	return procMetrics{Uptime: int64(elapsed), Memory: int64(rss), CPU: cpuPercent}, true
+}
+
+func processResourceSnapshotDarwin(pid int) (procMetrics, bool) {
+	out, err := commandOutput(2*time.Second, "/bin/ps", "-o", "etime=,rss=,%cpu=", "-p", strconv.Itoa(pid))
+	if err != nil {
+		return procMetrics{}, false
+	}
+	metrics, err := parseDarwinProcessMetrics(string(out))
+	if err != nil {
+		return procMetrics{}, false
+	}
+	return metrics, true
+}
+
+func parseDarwinProcessMetrics(text string) (procMetrics, error) {
+	fields := strings.Fields(strings.TrimSpace(text))
+	if len(fields) < 3 {
+		return procMetrics{}, errors.New("incomplete ps metrics")
+	}
+	uptime, err := parseElapsedTime(fields[0])
+	if err != nil {
+		return procMetrics{}, err
+	}
+	rssKB, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return procMetrics{}, err
+	}
+	rawCPU, err := strconv.ParseFloat(strings.TrimSuffix(fields[2], "%"), 64)
+	if err != nil {
+		return procMetrics{}, err
+	}
+	return procMetrics{
+		Uptime: int64(uptime),
+		Memory: int64(rssKB * 1024),
+		CPU:    roundMetric(normalizeProcessCPUPercent(rawCPU), 1),
+	}, nil
+}
+
+func parseElapsedTime(value string) (float64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, errors.New("empty elapsed time")
+	}
+	var days float64
+	if dayText, rest, ok := strings.Cut(value, "-"); ok {
+		parsedDays, err := strconv.ParseFloat(dayText, 64)
+		if err != nil {
+			return 0, err
+		}
+		days = parsedDays
+		value = rest
+	}
+	parts := strings.Split(value, ":")
+	if len(parts) < 1 || len(parts) > 3 {
+		return 0, errors.New("unsupported elapsed time")
+	}
+	values := make([]float64, len(parts))
+	for i, part := range parts {
+		parsed, err := strconv.ParseFloat(part, 64)
+		if err != nil {
+			return 0, err
+		}
+		values[i] = parsed
+	}
+	seconds := days * 24 * 60 * 60
+	switch len(values) {
+	case 1:
+		seconds += values[0]
+	case 2:
+		seconds += values[0]*60 + values[1]
+	case 3:
+		seconds += values[0]*60*60 + values[1]*60 + values[2]
+	}
+	return seconds, nil
 }
 
 func normalizeProcessCPUPercent(raw float64) float64 {
@@ -74,6 +158,11 @@ func clampPercentFloat(value float64) float64 {
 		return 100
 	}
 	return value
+}
+
+func roundMetric(value float64, precision int) float64 {
+	factor := math.Pow10(precision)
+	return math.Round(value*factor) / factor
 }
 
 func readProcRSSBytes(pid int) uint64 {
@@ -98,6 +187,13 @@ func readProcRSSBytes(pid int) uint64 {
 }
 
 func readSystemUptimeSeconds() float64 {
+	if runtime.GOOS == "darwin" {
+		out, err := commandOutput(time.Second, "/usr/sbin/sysctl", "-n", "kern.boottime")
+		if err != nil {
+			return 0
+		}
+		return parseDarwinSystemUptime(string(out), time.Now())
+	}
 	b, err := os.ReadFile("/proc/uptime")
 	if err != nil {
 		return 0
@@ -108,6 +204,24 @@ func readSystemUptimeSeconds() float64 {
 	}
 	value, _ := strconv.ParseFloat(fields[0], 64)
 	return value
+}
+
+var darwinBootSecondsRE = regexp.MustCompile(`\bsec\s*=\s*([0-9]+)`)
+
+func parseDarwinSystemUptime(text string, now time.Time) float64 {
+	match := darwinBootSecondsRE.FindStringSubmatch(text)
+	if len(match) != 2 {
+		return 0
+	}
+	bootSeconds, err := strconv.ParseInt(match[1], 10, 64)
+	if err != nil || bootSeconds <= 0 {
+		return 0
+	}
+	uptime := now.Sub(time.Unix(bootSeconds, 0)).Seconds()
+	if uptime < 0 {
+		return 0
+	}
+	return uptime
 }
 
 func readCPUTimes() (cpuTimes, error) {
@@ -136,6 +250,9 @@ func readCPUTimes() (cpuTimes, error) {
 }
 
 func sampleCPUPercent() float64 {
+	if runtime.GOOS == "darwin" {
+		return sampleDarwinCPUPercent()
+	}
 	if runtime.GOOS != "linux" {
 		return 0
 	}
@@ -156,7 +273,55 @@ func sampleCPUPercent() float64 {
 	return clampPercentFloat(float64(total-idle) * 100 / float64(total))
 }
 
+var darwinCPUUsageCache = struct {
+	sync.Mutex
+	at    time.Time
+	value float64
+}{}
+
+const darwinCPUUsageCacheTTL = time.Second
+
+func sampleDarwinCPUPercent() float64 {
+	darwinCPUUsageCache.Lock()
+	defer darwinCPUUsageCache.Unlock()
+	if !darwinCPUUsageCache.at.IsZero() && time.Since(darwinCPUUsageCache.at) < darwinCPUUsageCacheTTL {
+		return darwinCPUUsageCache.value
+	}
+	out, err := commandOutput(2*time.Second, "/usr/bin/top", "-l", "1", "-n", "0", "-s", "0")
+	if err != nil {
+		return darwinCPUUsageCache.value
+	}
+	value, err := parseDarwinCPUPercent(string(out))
+	if err != nil {
+		return darwinCPUUsageCache.value
+	}
+	darwinCPUUsageCache.at = time.Now()
+	darwinCPUUsageCache.value = roundMetric(value, 1)
+	return darwinCPUUsageCache.value
+}
+
+var darwinCPUIdleRE = regexp.MustCompile(`(?im)^CPU usage:.*?([0-9]+(?:\.[0-9]+)?)%\s+idle\s*$`)
+
+func parseDarwinCPUPercent(text string) (float64, error) {
+	matches := darwinCPUIdleRE.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return 0, errors.New("cpu usage line not found")
+	}
+	idle, err := strconv.ParseFloat(matches[len(matches)-1][1], 64)
+	if err != nil {
+		return 0, err
+	}
+	return clampPercentFloat(100 - idle), nil
+}
+
 func readNetworkCounters() []map[string]any {
+	if runtime.GOOS == "darwin" {
+		out, err := commandOutput(2*time.Second, "/usr/sbin/netstat", "-ibn")
+		if err != nil {
+			return nil
+		}
+		return parseDarwinNetworkCounters(string(out))
+	}
 	b, err := os.ReadFile("/proc/net/dev")
 	if err != nil {
 		return nil
@@ -177,6 +342,120 @@ func readNetworkCounters() []map[string]any {
 		rows = append(rows, map[string]any{"name": name, "rx_bytes": rx, "tx_bytes": tx})
 	}
 	return rows
+}
+
+func parseDarwinNetworkCounters(text string) []map[string]any {
+	lines := strings.Split(text, "\n")
+	nameIndex, networkIndex, inBytesIndex, outBytesIndex := -1, -1, -1, -1
+	rows := []map[string]any{}
+	seen := map[string]bool{}
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if fields[0] == "Name" {
+			for index, field := range fields {
+				switch field {
+				case "Name":
+					nameIndex = index
+				case "Network":
+					networkIndex = index
+				case "Ibytes":
+					inBytesIndex = index
+				case "Obytes":
+					outBytesIndex = index
+				}
+			}
+			continue
+		}
+		maxIndex := nameIndex
+		for _, index := range []int{networkIndex, inBytesIndex, outBytesIndex} {
+			if index > maxIndex {
+				maxIndex = index
+			}
+		}
+		if nameIndex < 0 || networkIndex < 0 || inBytesIndex < 0 || outBytesIndex < 0 || len(fields) <= maxIndex {
+			continue
+		}
+		if !strings.HasPrefix(fields[networkIndex], "<Link#") {
+			continue
+		}
+		name := strings.TrimSuffix(fields[nameIndex], "*")
+		if name == "" || seen[name] {
+			continue
+		}
+		rx, rxErr := strconv.ParseUint(fields[inBytesIndex], 10, 64)
+		tx, txErr := strconv.ParseUint(fields[outBytesIndex], 10, 64)
+		if rxErr != nil || txErr != nil {
+			continue
+		}
+		seen[name] = true
+		rows = append(rows, map[string]any{"name": name, "rx_bytes": rx, "tx_bytes": tx})
+	}
+	return rows
+}
+
+func readDarwinMemInfo() map[string]uint64 {
+	out := map[string]uint64{"MemTotal": 0, "MemAvailable": 0}
+	totalRaw, err := commandOutput(time.Second, "/usr/sbin/sysctl", "-n", "hw.memsize")
+	if err != nil {
+		return out
+	}
+	total, err := strconv.ParseUint(strings.TrimSpace(string(totalRaw)), 10, 64)
+	if err != nil {
+		return out
+	}
+	vmRaw, err := commandOutput(time.Second, "/usr/bin/vm_stat")
+	if err != nil {
+		out["MemTotal"] = total
+		return out
+	}
+	available := parseDarwinAvailableMemory(string(vmRaw))
+	if available > total {
+		available = total
+	}
+	out["MemTotal"] = total
+	out["MemAvailable"] = available
+	return out
+}
+
+var darwinVMPageSizeRE = regexp.MustCompile(`page size of\s+([0-9]+)\s+bytes`)
+
+func parseDarwinAvailableMemory(text string) uint64 {
+	pageSize := uint64(4096)
+	if match := darwinVMPageSizeRE.FindStringSubmatch(text); len(match) == 2 {
+		if parsed, err := strconv.ParseUint(match[1], 10, 64); err == nil && parsed > 0 {
+			pageSize = parsed
+		}
+	}
+	reclaimableKeys := map[string]bool{
+		"Pages free":        true,
+		"Pages inactive":    true,
+		"Pages speculative": true,
+		"Pages purgeable":   true,
+	}
+	var pages uint64
+	for _, line := range strings.Split(text, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok || !reclaimableKeys[strings.TrimSpace(key)] {
+			continue
+		}
+		value = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(value), "."))
+		parsed, err := strconv.ParseUint(value, 10, 64)
+		if err == nil {
+			pages += parsed
+		}
+	}
+	return pages * pageSize
+}
+
+func commandOutput(timeout time.Duration, path string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	return cmd.Output()
 }
 
 func diskUsage(path string) map[string]any {

--- a/internal/server/system_metrics_test.go
+++ b/internal/server/system_metrics_test.go
@@ -1,43 +1,207 @@
 package server
 
 import (
+	"encoding/json"
 	"math"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"runtime"
 	"testing"
+	"time"
 )
 
-func TestNormalizeProcessCPUPercentUsesLogicalCPUCapacity(t *testing.T) {
-	capacity := runtime.NumCPU()
-	if capacity < 1 {
-		capacity = 1
+func TestParseDarwinSystemMetrics(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	uptime := parseDarwinSystemUptime("{ sec = 1799996400, usec = 123456 }", now)
+	if uptime != 3600 {
+		t.Fatalf("unexpected uptime: %v", uptime)
 	}
-	raw := float64(capacity) * 87.5
-	got := normalizeProcessCPUPercent(raw)
-	if math.Abs(got-87.5) > 0.001 {
-		t.Fatalf("normalized cpu = %.3f, want 87.5", got)
+
+	cpu, err := parseDarwinCPUPercent("CPU usage: 7.23% user, 11.97% sys, 80.79% idle\n")
+	if err != nil || math.Abs(cpu-19.21) > 0.001 {
+		t.Fatalf("unexpected cpu parse: cpu=%v err=%v", cpu, err)
+	}
+
+	available := parseDarwinAvailableMemory(`Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                                1000.
+Pages active:                              900.
+Pages inactive:                           2000.
+Pages speculative:                         300.
+Pages purgeable:                           400.
+Pages occupied by compressor:              800.
+`)
+	if want := uint64(3700 * 16384); available != want {
+		t.Fatalf("unexpected available memory: got=%d want=%d", available, want)
 	}
 }
 
-func TestNormalizeProcessCPUPercentClampsInvalidValues(t *testing.T) {
-	capacity := runtime.NumCPU()
-	if capacity < 1 {
-		capacity = 1
+func TestParseDarwinNetworkCountersUsesLinkRowsOnce(t *testing.T) {
+	rows := parseDarwinNetworkCounters(`Name       Mtu   Network       Address            Ipkts Ierrs     Ibytes    Opkts Oerrs     Obytes  Coll
+lo0        16384 <Link#1>                       10     0       1000       10     0       2000     0
+lo0        16384 127           127.0.0.1        10     -       1000       10     -       2000     -
+en0        1500  <Link#7>    aa:bb:cc:dd:ee:ff  20     0       3000       30     0       4000     0
+en0        1500  192.168.1    192.168.1.10      20     -       3000       30     -       4000     -
+gif0*      1280  <Link#2>                       0      0       0          0      0       0        0
+`)
+	if len(rows) != 3 {
+		t.Fatalf("expected three unique link rows, got %#v", rows)
 	}
-	tests := []struct {
-		name string
-		raw  float64
-		want float64
-	}{
-		{name: "negative", raw: -1, want: 0},
-		{name: "nan", raw: math.NaN(), want: 0},
-		{name: "infinity", raw: math.Inf(1), want: 0},
-		{name: "over capacity", raw: float64(capacity) * 350, want: 100},
+	if stringMapValue(rows[1], "name") != "en0" || uint64FromAny(rows[1]["rx_bytes"]) != 3000 || uint64FromAny(rows[1]["tx_bytes"]) != 4000 {
+		t.Fatalf("unexpected en0 counters: %#v", rows[1])
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeProcessCPUPercent(tt.raw); got != tt.want {
-				t.Fatalf("normalized cpu = %.3f, want %.3f", got, tt.want)
-			}
-		})
+	if stringMapValue(rows[2], "name") != "gif0" {
+		t.Fatalf("interface marker should be removed: %#v", rows[2])
+	}
+}
+
+func TestParseDarwinProcessMetrics(t *testing.T) {
+	metrics, err := parseDarwinProcessMetrics("2-03:04:05 4096 42.0\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metrics.Uptime != 2*86400+3*3600+4*60+5 {
+		t.Fatalf("unexpected process uptime: %d", metrics.Uptime)
+	}
+	if metrics.Memory != 4096*1024 {
+		t.Fatalf("unexpected RSS bytes: %d", metrics.Memory)
+	}
+	wantCPU := roundMetric(normalizeProcessCPUPercent(42), 1)
+	if metrics.CPU != wantCPU {
+		t.Fatalf("unexpected process cpu: got=%v want=%v", metrics.CPU, wantCPU)
+	}
+}
+
+func TestDarwinCollectorsReturnLiveValues(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Darwin collector integration test")
+	}
+	if uptime := readSystemUptimeSeconds(); uptime <= 0 {
+		t.Fatalf("system uptime should be positive, got %v", uptime)
+	}
+	mem := readMemInfo()
+	if mem["MemTotal"] == 0 || mem["MemAvailable"] == 0 || mem["MemAvailable"] > mem["MemTotal"] {
+		t.Fatalf("unexpected memory snapshot: %#v", mem)
+	}
+	if rows := readNetworkCounters(); len(rows) == 0 {
+		t.Fatal("network counters should not be empty")
+	}
+	if metrics, ok := processResourceSnapshot(os.Getpid()); !ok || metrics.Memory <= 0 {
+		t.Fatalf("current process metrics unavailable: ok=%v metrics=%#v", ok, metrics)
+	}
+	if model := cpuModel(); model == "" || model == runtime.GOARCH {
+		t.Fatalf("expected Darwin CPU model, got %q", model)
+	}
+}
+
+func TestMonitorHistoryUsesNormalizedNetworkObject(t *testing.T) {
+	controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/connections" {
+			writeJSON(w, http.StatusOK, map[string]any{"connections": []any{}, "downloadTotal": 0, "uploadTotal": 0})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer controller.Close()
+
+	app := newTestApp(t)
+	app.setSetting("mihomo_controller_endpoint", controller.URL)
+	token := tokenForRole(t, app, "admin")
+	res := requestJSON(t, app, http.MethodGet, "/api/v1/monitor/history", token, nil)
+	if res.Code != http.StatusOK {
+		t.Fatalf("history status=%d body=%s", res.Code, res.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	points := anySlice(body["data"])
+	if len(points) != 1 {
+		t.Fatalf("unexpected history points: %#v", body)
+	}
+	point, _ := points[0].(map[string]any)
+	if _, ok := point["network"].(map[string]any); !ok {
+		t.Fatalf("network history must be an object: %#v", point["network"])
+	}
+	for _, key := range []string{"download_speed", "upload_speed", "connections", "connection_count"} {
+		if _, ok := point[key]; !ok {
+			t.Fatalf("history point missing %s: %#v", key, point)
+		}
+	}
+}
+
+func TestMonitorNetworkNearConcurrentCallKeepsCachedRate(t *testing.T) {
+	controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"connections": []any{}, "downloadTotal": 0, "uploadTotal": 0})
+	}))
+	defer controller.Close()
+
+	app := newTestApp(t)
+	app.setSetting("mihomo_controller_endpoint", controller.URL)
+	now := time.Now()
+	app.monitorNetworkLast = monitorNetworkSample{At: now, RXBytes: 1, TXBytes: 1}
+	app.monitorNetworkCache = map[string]any{
+		"download_speed": float64(1234),
+		"upload_speed":   float64(567),
+		"down_speed":     float64(1234),
+		"up_speed":       float64(567),
+		"downloadSpeed":  float64(1234),
+		"uploadSpeed":    float64(567),
+	}
+	got := app.monitorNetworkSnapshot(now.Add(100 * time.Millisecond))
+	if numericMapValue(got, "download_speed") != 1234 || numericMapValue(got, "upload_speed") != 567 {
+		t.Fatalf("near-concurrent poll should keep cached rates: %#v", got)
+	}
+}
+
+func TestMihomoTrafficCacheReturnsStaleValueWhileRefreshing(t *testing.T) {
+	controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/traffic" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"up": 900, "down": 1200})
+	}))
+	defer controller.Close()
+
+	app := newTestApp(t)
+	app.setSetting("mihomo_controller_endpoint", controller.URL)
+	app.mihomoTrafficCache = map[string]any{"up": float64(90), "down": float64(120), "upload": float64(90), "download": float64(120)}
+	app.mihomoTrafficAt = time.Now().Add(-mihomoTrafficCacheTTL - time.Second)
+
+	got := app.mihomoTrafficCachedPayload()
+	if numericMapValue(got, "up") != 90 || numericMapValue(got, "down") != 120 {
+		t.Fatalf("expired cache should remain visible during refresh: %#v", got)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if refreshed, ok := app.cachedMihomoTraffic(); ok && numericMapValue(refreshed, "up") == 900 && numericMapValue(refreshed, "down") == 1200 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("traffic cache did not refresh")
+}
+
+func TestMihomoTrafficDerivesRateFromConnectionTotals(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	app.mihomoTrafficTotalsLast = mihomoTrafficTotalsSample{
+		At:            now,
+		DownloadTotal: 1000,
+		UploadTotal:   500,
+		DownloadRate:  25,
+		UploadRate:    10,
+	}
+
+	got := app.deriveMihomoTrafficFromTotals(1600, 800, now.Add(2*time.Second))
+	if numericMapValue(got, "down") != 300 || numericMapValue(got, "up") != 150 {
+		t.Fatalf("unexpected derived rate: %#v", got)
+	}
+
+	nearConcurrent := app.deriveMihomoTrafficFromTotals(1610, 805, now.Add(2100*time.Millisecond))
+	if numericMapValue(nearConcurrent, "down") != 300 || numericMapValue(nearConcurrent, "up") != 150 {
+		t.Fatalf("near-concurrent overview should keep the last rate: %#v", nearConcurrent)
 	}
 }

--- a/macos/MSFMenuBar/Package.swift
+++ b/macos/MSFMenuBar/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "MSFMenuBar",
+    platforms: [
+        .macOS(.v15),
+    ],
+    products: [
+        .library(name: "MSFMenuBarCore", targets: ["MSFMenuBarCore"]),
+        .executable(name: "MSFMenuBar", targets: ["MSFMenuBarApp"]),
+    ],
+    targets: [
+        .target(name: "MSFMenuBarCore"),
+        .executableTarget(
+            name: "MSFMenuBarApp",
+            dependencies: ["MSFMenuBarCore"]
+        ),
+        .testTarget(
+            name: "MSFMenuBarCoreTests",
+            dependencies: ["MSFMenuBarCore"]
+        ),
+    ]
+)

--- a/macos/MSFMenuBar/README.md
+++ b/macos/MSFMenuBar/README.md
@@ -1,0 +1,64 @@
+# MSF Menu Bar for macOS
+
+原生 SwiftUI 菜单栏客户端，最低支持 macOS 15。App 本身不持有 root 权限，也不直接修改 DNS、路由或 TUN；所有系统操作都通过本机 MSF root LaunchDaemon 完成。
+
+v0.4.0 是 macOS App 的首个 Beta 版本。完整安装、LAN 路由要求、验证和回退步骤见 [macOS 安装与使用](../../docs/install/macos.md)。
+
+## 功能
+
+- 启动 MSF 数据面。
+- 安全停止并保持 LAN 直连。
+- 重启 MosDNS、Mihomo 和 TUN 数据面。
+- 带风险确认的完全停止。
+- 打开 MSF 网页管理页。
+- 在菜单栏和菜单内显示 Mihomo/TUN 实时上下行速度。
+- 使用管理员账户创建 `operate` API Token，或直接录入现有 Token。
+- Token 仅保存在 macOS Keychain，管理员密码不会保存。
+
+## 架构边界
+
+- `MSFMenuBarCore`：API、运行状态解析、Keychain 和速度格式化。
+- `MSFMenuBarApp`：`MenuBarExtra`、连接设置和原生菜单交互。
+- macOS 后台使用统一 `/api/v1/network/runtime/*` 状态机。
+- 客户端保留 `/api/v1/services/*` 与 `/api/v1/mihomo/traffic` 兼容逻辑，便于识别旧后台。
+- 旧后台无法安全实现“停止并让 LAN 直连保活”，因此该操作会保持禁用，不会静默退化为完全停机。
+- Debug App 使用 legacy LaunchDaemon 安装器；签名 Release App 使用 `SMAppService`。
+
+## 本地开发
+
+要求：完整 Xcode 16 或更高版本、XcodeGen 2.45 或更高版本。
+
+```bash
+make macos-app-project
+make macos-app-test
+make macos-app-build-debug macos-app-build-release
+make macos-app-verify MACOS_CONFIGURATION=Debug
+make macos-app-verify MACOS_CONFIGURATION=Release
+make macos-app-open
+```
+
+如果系统 `xcode-select` 没有指向完整 Xcode，可只为命令指定路径：
+
+```bash
+make macos-app-build XCODE_DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+```
+
+生成后的工程位于 `macos/MSFMenuBar/MSFMenuBar.xcodeproj`。工程文件和构建产物由 XcodeGen 重建，不提交到 Git。
+
+默认后台地址为 `http://127.0.0.1:7777`。首次启动后进入“连接设置”，使用管理员账户配对或粘贴 `operate` Token。
+
+## 正式发布
+
+签名发布需要 Developer ID Application、Apple Notary API 凭据和干净且已打 tag 的源码：
+
+```bash
+make macos-release-assets \
+  VERSION=0.4.0 \
+  RELEASE_TAG=v0.4.0 \
+  MACOS_BUILD_NUMBER=1 \
+  MACOS_DEVELOPMENT_TEAM=<TEAM_ID> \
+  MACOS_SIGNING_IDENTITY=<DEVELOPER_ID_IDENTITY> \
+  MACOS_NOTARY_PROFILE=<NOTARY_PROFILE>
+```
+
+该目标会构建、签名并公证 Universal 2 App，随后在 `dist/macos/` 生成 DMG、ZIP 和 SHA-256。

--- a/macos/MSFMenuBar/Resources/io.github.scoltzero.msf.daemon.legacy.plist
+++ b/macos/MSFMenuBar/Resources/io.github.scoltzero.msf.daemon.legacy.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.github.scoltzero.msf.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Library/PrivilegedHelperTools/io.github.scoltzero.msf.daemon</string>
+    <string>serve</string>
+    <string>--config</string>
+    <string>/Library/Application Support/MSF</string>
+    <string>--host</string>
+    <string>127.0.0.1</string>
+    <string>--port</string>
+    <string>7777</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>MSF_RUNTIME</key>
+    <string>macos</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>StandardOutPath</key>
+  <string>/Library/Logs/MSF/msf-daemon.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Library/Logs/MSF/msf-daemon.err.log</string>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>65536</integer>
+  </dict>
+</dict>
+</plist>

--- a/macos/MSFMenuBar/Resources/io.github.scoltzero.msf.daemon.plist
+++ b/macos/MSFMenuBar/Resources/io.github.scoltzero.msf.daemon.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.github.scoltzero.msf.daemon</string>
+  <key>BundleProgram</key>
+  <string>Contents/Library/HelperTools/io.github.scoltzero.msf.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>io.github.scoltzero.msf.daemon</string>
+    <string>serve</string>
+    <string>--config</string>
+    <string>/Library/Application Support/MSF</string>
+    <string>--host</string>
+    <string>127.0.0.1</string>
+    <string>--port</string>
+    <string>7777</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>MSF_RUNTIME</key>
+    <string>macos</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>65536</integer>
+  </dict>
+</dict>
+</plist>

--- a/macos/MSFMenuBar/Resources/msf-daemon-installer.sh
+++ b/macos/MSFMenuBar/Resources/msf-daemon-installer.sh
@@ -1,0 +1,63 @@
+#!/bin/zsh
+set -euo pipefail
+
+label="io.github.scoltzero.msf.daemon"
+helper_path="/Library/PrivilegedHelperTools/$label"
+plist_path="/Library/LaunchDaemons/$label.plist"
+data_path="/Library/Application Support/MSF"
+log_path="/Library/Logs/MSF"
+
+if [[ "$(/usr/bin/id -u)" -ne 0 ]]; then
+  echo "installer must run as root" >&2
+  exit 1
+fi
+
+action="${1:-install}"
+app_bundle="${2:-}"
+
+stop_service() {
+  /bin/launchctl bootout "system/$label" >/dev/null 2>&1 || true
+  /bin/launchctl bootout system "$plist_path" >/dev/null 2>&1 || true
+}
+
+case "$action" in
+  install|repair)
+    if [[ -z "$app_bundle" ]]; then
+      echo "app bundle path is required" >&2
+      exit 1
+    fi
+    source_helper="$app_bundle/Contents/Library/HelperTools/$label"
+    source_plist="$app_bundle/Contents/Resources/$label.legacy.plist"
+    if [[ ! -x "$source_helper" ]]; then
+      echo "bundled daemon is missing: $source_helper" >&2
+      exit 1
+    fi
+    if [[ ! -f "$source_plist" ]]; then
+      echo "legacy launchd plist is missing: $source_plist" >&2
+      exit 1
+    fi
+
+    stop_service
+    /usr/bin/install -d -o root -g wheel -m 0755 /Library/PrivilegedHelperTools /Library/LaunchDaemons
+    /usr/bin/install -d -o root -g wheel -m 0750 "$data_path"
+    /usr/bin/install -d -o root -g wheel -m 0755 "$log_path"
+    /usr/bin/install -o root -g wheel -m 0755 "$source_helper" "$helper_path"
+    /usr/bin/install -o root -g wheel -m 0644 "$source_plist" "$plist_path"
+    /usr/bin/xattr -d com.apple.quarantine "$helper_path" >/dev/null 2>&1 || true
+    /usr/bin/codesign --force --sign - "$helper_path" >/dev/null 2>&1
+    /usr/bin/plutil -lint "$plist_path" >/dev/null
+    /bin/launchctl bootstrap system "$plist_path"
+    /bin/launchctl enable "system/$label"
+    /bin/launchctl kickstart -k "system/$label"
+    echo "installed:$label"
+    ;;
+  uninstall)
+    stop_service
+    /bin/rm -f "$plist_path" "$helper_path"
+    echo "uninstalled:$label:data-preserved:$data_path"
+    ;;
+  *)
+    echo "usage: $0 install|repair|uninstall [app-bundle]" >&2
+    exit 2
+    ;;
+esac

--- a/macos/MSFMenuBar/Scripts/embed-daemon.sh
+++ b/macos/MSFMenuBar/Scripts/embed-daemon.sh
@@ -1,0 +1,55 @@
+#!/bin/zsh
+set -euo pipefail
+
+project_root="$(cd "$SRCROOT/../.." && /bin/pwd)"
+work_root="$DERIVED_FILE_DIR/MSFDaemon"
+app_contents="$TARGET_BUILD_DIR/$CONTENTS_FOLDER_PATH"
+helper_name="io.github.scoltzero.msf.daemon"
+helper_dir="$app_contents/Library/HelperTools"
+launchd_dir="$app_contents/Library/LaunchDaemons"
+resource_dir="$app_contents/Resources"
+
+version="${MSF_VERSION:-${MARKETING_VERSION:-0.4.0}}"
+build_commit="${MSF_BUILD_COMMIT:-$(cd "$project_root" && git rev-parse HEAD 2>/dev/null || printf unknown)}"
+build_tag="${MSF_BUILD_TAG:-dev}"
+build_tag_commit="${MSF_BUILD_TAG_COMMIT:-unknown}"
+build_source_commit="${MSF_BUILD_SOURCE_COMMIT:-$build_commit}"
+build_dirty="${MSF_BUILD_DIRTY:-$(cd "$project_root" && test -z "$(git status --porcelain 2>/dev/null)" && printf false || printf true)}"
+build_time="${MSF_BUILD_TIME:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+ldflags="-s -w -X main.version=$version -X main.buildCommit=$build_commit -X main.buildTag=$build_tag -X main.buildTagCommit=$build_tag_commit -X main.buildSourceCommit=$build_source_commit -X main.buildDirty=$build_dirty -X main.buildTime=$build_time"
+
+/bin/mkdir -p "$work_root" "$helper_dir" "$launchd_dir" "$resource_dir"
+
+build_daemon() {
+  local arch="$1"
+  local output="$work_root/msf-daemon-$arch"
+  (
+    cd "$project_root"
+    CGO_ENABLED=0 GOOS=darwin GOARCH="$arch" /usr/bin/env go build \
+      -buildvcs=true \
+      -trimpath \
+      -ldflags "$ldflags" \
+      -o "$output" \
+      ./cmd/msf
+  )
+}
+
+build_daemon arm64
+build_daemon amd64
+/usr/bin/xcrun lipo -create \
+  "$work_root/msf-daemon-arm64" \
+  "$work_root/msf-daemon-amd64" \
+  -output "$helper_dir/$helper_name"
+/bin/chmod 0755 "$helper_dir/$helper_name"
+
+/bin/cp "$SRCROOT/Resources/$helper_name.plist" "$launchd_dir/$helper_name.plist"
+/bin/cp "$SRCROOT/Resources/$helper_name.legacy.plist" "$resource_dir/$helper_name.legacy.plist"
+/bin/cp "$SRCROOT/Resources/msf-daemon-installer.sh" "$resource_dir/msf-daemon-installer.sh"
+/bin/chmod 0755 "$resource_dir/msf-daemon-installer.sh"
+
+sign_identity="${EXPANDED_CODE_SIGN_IDENTITY:-}"
+if [[ "${CODE_SIGNING_ALLOWED:-NO}" == "YES" && -n "$sign_identity" && "$sign_identity" != "-" ]]; then
+  /usr/bin/codesign --force --timestamp --options runtime --sign "$sign_identity" "$helper_dir/$helper_name"
+else
+  /usr/bin/codesign --force --sign - "$helper_dir/$helper_name"
+fi

--- a/macos/MSFMenuBar/Scripts/package-release.sh
+++ b/macos/MSFMenuBar/Scripts/package-release.sh
@@ -1,0 +1,78 @@
+#!/bin/zsh
+set -euo pipefail
+
+version="${1:?version is required}"
+release_tag="${2:?release tag is required}"
+expected_commit="${3:?expected commit is required}"
+output_dir="${4:?output directory is required}"
+sign_identity="${MACOS_SIGNING_IDENTITY:?MACOS_SIGNING_IDENTITY is required}"
+notary_profile="${MACOS_NOTARY_PROFILE:?MACOS_NOTARY_PROFILE is required}"
+
+project_root="$(cd "$(dirname "$0")/.." && /bin/pwd)"
+app="$project_root/DerivedData/Build/Products/Release/MSF.app"
+asset_prefix="MSF-$version-macos-universal"
+dmg="$output_dir/$asset_prefix.dmg"
+zip="$output_dir/$asset_prefix.zip"
+tmp="$(/usr/bin/mktemp -d)"
+
+cleanup() {
+  /bin/rm -rf "$tmp"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  echo "package-release: $*" >&2
+  exit 1
+}
+
+[[ "$release_tag" == "v$version" ]] || fail "$release_tag does not match version $version"
+[[ -d "$app" ]] || fail "Release app not found: $app"
+
+MSF_EXPECTED_VERSION="$version" \
+MSF_EXPECTED_COMMIT="$expected_commit" \
+MSF_EXPECTED_TAG="$release_tag" \
+MSF_REQUIRE_DEVELOPER_ID=1 \
+  "$project_root/Scripts/verify-app.sh" Release
+
+/bin/mkdir -p "$output_dir"
+/bin/rm -f "$dmg" "$dmg.sha256" "$zip" "$zip.sha256"
+
+notary_zip="$tmp/MSF-notary.zip"
+/usr/bin/ditto -c -k --sequesterRsrc --keepParent "$app" "$notary_zip"
+/usr/bin/xcrun notarytool submit "$notary_zip" --keychain-profile "$notary_profile" --wait
+/usr/bin/xcrun stapler staple "$app"
+/usr/bin/xcrun stapler validate "$app"
+/usr/sbin/spctl --assess --type execute --verbose=2 "$app"
+
+/usr/bin/ditto -c -k --sequesterRsrc --keepParent "$app" "$zip"
+
+dmg_root="$tmp/dmg-root"
+/bin/mkdir -p "$dmg_root"
+/usr/bin/ditto "$app" "$dmg_root/MSF.app"
+/bin/ln -s /Applications "$dmg_root/Applications"
+/usr/bin/hdiutil create \
+  -volname "MSF" \
+  -srcfolder "$dmg_root" \
+  -ov \
+  -format UDZO \
+  "$dmg"
+/usr/bin/codesign --force --timestamp --sign "$sign_identity" "$dmg"
+/usr/bin/xcrun notarytool submit "$dmg" --keychain-profile "$notary_profile" --wait
+/usr/bin/xcrun stapler staple "$dmg"
+/usr/bin/xcrun stapler validate "$dmg"
+/usr/sbin/spctl --assess --type open --context context:primary-signature --verbose=2 "$dmg"
+
+zip_check="$tmp/zip-check"
+/bin/mkdir -p "$zip_check"
+/usr/bin/ditto -x -k "$zip" "$zip_check"
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$zip_check/MSF.app"
+/usr/bin/xcrun stapler validate "$zip_check/MSF.app"
+
+(
+  cd "$output_dir"
+  /usr/bin/shasum -a 256 "$(basename "$dmg")" > "$(basename "$dmg").sha256"
+  /usr/bin/shasum -a 256 "$(basename "$zip")" > "$(basename "$zip").sha256"
+)
+
+echo "packaged:$dmg"
+echo "packaged:$zip"

--- a/macos/MSFMenuBar/Scripts/verify-app.sh
+++ b/macos/MSFMenuBar/Scripts/verify-app.sh
@@ -1,0 +1,99 @@
+#!/bin/zsh
+set -euo pipefail
+
+configuration="${1:-Debug}"
+project_root="$(cd "$(dirname "$0")/.." && /bin/pwd)"
+app="$project_root/DerivedData/Build/Products/$configuration/MSF.app"
+main_binary="$app/Contents/MacOS/MSF"
+helper_name="io.github.scoltzero.msf.daemon"
+helper="$app/Contents/Library/HelperTools/$helper_name"
+service_plist="$app/Contents/Library/LaunchDaemons/$helper_name.plist"
+legacy_plist="$app/Contents/Resources/$helper_name.legacy.plist"
+installer="$app/Contents/Resources/msf-daemon-installer.sh"
+expected_version="${MSF_EXPECTED_VERSION:-}"
+expected_commit="${MSF_EXPECTED_COMMIT:-}"
+expected_tag="${MSF_EXPECTED_TAG:-}"
+require_developer_id="${MSF_REQUIRE_DEVELOPER_ID:-0}"
+
+fail() {
+  echo "verify-app: $*" >&2
+  exit 1
+}
+
+[[ -d "$app" ]] || fail "app bundle not found: $app"
+[[ -x "$main_binary" ]] || fail "main executable missing: $main_binary"
+[[ -x "$helper" ]] || fail "embedded daemon missing: $helper"
+[[ -f "$service_plist" ]] || fail "SMAppService plist missing: $service_plist"
+[[ -f "$legacy_plist" ]] || fail "legacy LaunchDaemon plist missing: $legacy_plist"
+[[ -x "$installer" ]] || fail "legacy installer missing or not executable: $installer"
+
+for binary in "$main_binary" "$helper"; do
+  archs="$(/usr/bin/lipo -archs "$binary")"
+  [[ " $archs " == *" arm64 "* ]] || fail "$(basename "$binary") does not contain arm64: $archs"
+  [[ " $archs " == *" x86_64 "* ]] || fail "$(basename "$binary") does not contain x86_64: $archs"
+done
+
+/usr/bin/plutil -lint "$app/Contents/Info.plist" "$service_plist" "$legacy_plist" >/dev/null
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :LSUIElement' "$app/Contents/Info.plist")" == "true" ]] \
+  || fail "LSUIElement must be true for a menu bar-only app"
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$app/Contents/Info.plist")" == "15.0" ]] \
+  || fail "minimum macOS version must remain 15.0"
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Contents/Info.plist")" == "io.github.scoltzero.msf.menubar" ]] \
+  || fail "unexpected app bundle identifier"
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :BundleProgram' "$service_plist")" == "Contents/Library/HelperTools/$helper_name" ]] \
+  || fail "SMAppService BundleProgram does not point at the embedded daemon"
+
+bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist")"
+bundle_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app/Contents/Info.plist")"
+[[ -n "$bundle_build" ]] || fail "CFBundleVersion must not be empty"
+if [[ -n "$expected_version" ]]; then
+  [[ "$bundle_version" == "$expected_version" ]] \
+    || fail "bundle version $bundle_version does not match $expected_version"
+fi
+
+/bin/zsh -n "$project_root/Scripts/embed-daemon.sh"
+/bin/zsh -n "$project_root/Resources/msf-daemon-installer.sh"
+/bin/zsh -n "$installer"
+/usr/bin/codesign --verify --strict "$helper"
+
+provenance="$("$helper" version --json)" || fail "cannot read embedded daemon provenance"
+/usr/bin/python3 - "$provenance" "$expected_version" "$expected_commit" "$expected_tag" <<'PY' \
+  || fail "embedded daemon provenance mismatch"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+expected = {
+    "version": sys.argv[2],
+    "commit": sys.argv[3],
+    "tag": sys.argv[4],
+}
+if sys.argv[3]:
+    expected["source_commit"] = sys.argv[3]
+if sys.argv[3] and sys.argv[4]:
+    expected["tag_commit"] = sys.argv[3]
+    expected["dirty"] = "false"
+for key, value in expected.items():
+    if value and payload.get(key) != value:
+        raise SystemExit(f"{key}={payload.get(key)!r}, want {value!r}")
+PY
+
+if [[ "$require_developer_id" == "1" ]]; then
+  /usr/bin/codesign --verify --deep --strict --verbose=2 "$app"
+  app_signature="$(/usr/bin/codesign -dvvv "$app" 2>&1)"
+  helper_signature="$(/usr/bin/codesign -dvvv "$helper" 2>&1)"
+  [[ "$app_signature" == *"Authority=Developer ID Application:"* ]] \
+    || fail "app is not signed with Developer ID Application"
+  [[ "$helper_signature" == *"Authority=Developer ID Application:"* ]] \
+    || fail "daemon is not signed with Developer ID Application"
+  [[ "$app_signature" == *"flags="*"runtime"* ]] \
+    || fail "app Hardened Runtime flag is missing"
+  [[ "$helper_signature" == *"flags="*"runtime"* ]] \
+    || fail "daemon Hardened Runtime flag is missing"
+fi
+
+echo "verified:$configuration:$app"
+echo "bundle-version:$bundle_version"
+echo "bundle-build:$bundle_build"
+echo "main-archs:$(/usr/bin/lipo -archs "$main_binary")"
+echo "daemon-archs:$(/usr/bin/lipo -archs "$helper")"

--- a/macos/MSFMenuBar/Sources/MSFMenuBarApp/ConnectionSettingsView.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarApp/ConnectionSettingsView.swift
@@ -1,0 +1,145 @@
+import AppKit
+import MSFMenuBarCore
+import SwiftUI
+
+struct ConnectionSettingsView: View {
+  @ObservedObject var model: MenuBarModel
+  @StateObject private var daemon = DaemonServiceModel()
+
+  @State private var serverURL = ""
+  @State private var username = ""
+  @State private var password = ""
+  @State private var manualToken = ""
+
+  var body: some View {
+    Form {
+      Section("系统后台") {
+        HStack {
+          Label(daemon.title, systemImage: daemon.symbolName)
+          Spacer()
+          if daemon.isBusy {
+            ProgressView()
+              .controlSize(.small)
+          }
+        }
+
+        Text(daemon.detail)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+
+        HStack {
+          Button(daemon.canUninstall ? "修复后台" : "安装后台") {
+            daemon.install()
+          }
+          .disabled(!daemon.canInstall)
+
+          if daemon.canUninstall {
+            Button("卸载后台", role: .destructive) {
+              daemon.uninstall()
+            }
+            .disabled(daemon.isBusy)
+          }
+
+          if daemon.state == .approvalRequired {
+            Button("打开系统设置") {
+              daemon.openApprovalSettings()
+            }
+          }
+
+          Button("刷新") {
+            Task { await daemon.refresh() }
+          }
+          .disabled(daemon.isBusy)
+        }
+      }
+
+      Section("后台连接") {
+        TextField("后台地址", text: $serverURL)
+          .textFieldStyle(.roundedBorder)
+
+        HStack {
+          Label(
+            model.hasToken ? "已保存 API Token" : "尚未连接",
+            systemImage: model.hasToken ? "checkmark.shield" : "exclamationmark.triangle"
+          )
+          Spacer()
+          Button("保存地址") {
+            _ = model.saveBaseURL(serverURL)
+          }
+        }
+      }
+
+      Section("使用管理员账户绑定") {
+        TextField("用户名", text: $username)
+          .textFieldStyle(.roundedBorder)
+        SecureField("密码", text: $password)
+          .textFieldStyle(.roundedBorder)
+
+        Button(model.isPairing ? "正在连接…" : "连接并创建 operate Token") {
+          Task {
+            if await model.pair(
+              baseURL: serverURL,
+              username: username,
+              password: password
+            ) {
+              password = ""
+            }
+          }
+        }
+        .disabled(model.isPairing || username.isEmpty || password.isEmpty)
+
+        Text("密码只用于本次登录，不会保存；长期凭据保存在 macOS Keychain。")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
+      Section("已有 API Token") {
+        SecureField("msf_…", text: $manualToken)
+          .textFieldStyle(.roundedBorder)
+
+        HStack {
+          Button("保存 Token") {
+            Task {
+              if await model.saveManualToken(
+                baseURL: serverURL,
+                token: manualToken
+              ) {
+                manualToken = ""
+              }
+            }
+          }
+          .disabled(manualToken.isEmpty)
+
+          Button("打开网页管理页") {
+            if let url = try? MSFEndpoint.normalize(serverURL) {
+              NSWorkspace.shared.open(url)
+            }
+          }
+        }
+      }
+
+      if let error = model.lastError, !error.isEmpty {
+        Section("连接信息") {
+          Text(error)
+            .foregroundStyle(.red)
+            .textSelection(.enabled)
+        }
+      }
+
+      Section {
+        Button("断开连接", role: .destructive) {
+          model.disconnect()
+        }
+        .disabled(!model.hasToken)
+      }
+    }
+    .formStyle(.grouped)
+    .padding()
+    .frame(width: 520, height: 680)
+    .onAppear {
+      serverURL = model.baseURLString
+      Task { await daemon.refresh() }
+    }
+  }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarApp/DaemonServiceModel.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarApp/DaemonServiceModel.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ServiceManagement
+@preconcurrency import ServiceManagement
 
 @MainActor
 final class DaemonServiceModel: ObservableObject {

--- a/macos/MSFMenuBar/Sources/MSFMenuBarApp/DaemonServiceModel.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarApp/DaemonServiceModel.swift
@@ -1,0 +1,235 @@
+import Foundation
+import ServiceManagement
+
+@MainActor
+final class DaemonServiceModel: ObservableObject {
+  enum State: Equatable {
+    case checking
+    case notInstalled
+    case approvalRequired
+    case installed
+    case running
+    case failed(String)
+  }
+
+  @Published private(set) var state: State = .checking
+  @Published private(set) var isBusy = false
+  @Published private(set) var detail = "正在检查 MSF 后台…"
+
+  private static let label = "io.github.scoltzero.msf.daemon"
+  private static let plistName = label + ".plist"
+  private static let helperPath = "/Library/PrivilegedHelperTools/" + label
+  private let service = SMAppService.daemon(plistName: plistName)
+
+  var title: String {
+    switch state {
+    case .checking:
+      "正在检查"
+    case .notInstalled:
+      "后台未安装"
+    case .approvalRequired:
+      "等待系统批准"
+    case .installed:
+      "后台已安装"
+    case .running:
+      "后台运行中"
+    case .failed:
+      "后台操作失败"
+    }
+  }
+
+  var symbolName: String {
+    switch state {
+    case .running:
+      "checkmark.circle.fill"
+    case .installed, .approvalRequired:
+      "clock.badge.checkmark"
+    case .failed:
+      "exclamationmark.triangle.fill"
+    case .checking:
+      "arrow.triangle.2.circlepath"
+    case .notInstalled:
+      "externaldrive.badge.xmark"
+    }
+  }
+
+  var canInstall: Bool {
+    !isBusy && state != .running
+  }
+
+  var canUninstall: Bool {
+    if isBusy { return false }
+    switch state {
+    case .installed, .running, .approvalRequired:
+      return true
+    default:
+      return FileManager.default.fileExists(atPath: Self.helperPath)
+    }
+  }
+
+  func refresh() async {
+    let reachable = await backendReachable()
+    if reachable {
+      state = .running
+      detail = "LaunchDaemon 正在 127.0.0.1:7777 提供服务"
+      return
+    }
+    if FileManager.default.fileExists(atPath: Self.helperPath) {
+      state = .installed
+      detail = "后台文件已安装，但端口 7777 尚未就绪"
+      return
+    }
+    switch service.status {
+    case .enabled:
+      state = .installed
+      detail = "系统服务已启用，正在等待后台启动"
+    case .requiresApproval:
+      state = .approvalRequired
+      detail = "请在“系统设置 → 通用 → 登录项与扩展”中允许 MSF"
+    case .notRegistered, .notFound:
+      state = .notInstalled
+      detail = "安装后由 root LaunchDaemon 管理 TUN、DNS 和路由"
+    @unknown default:
+      state = .notInstalled
+      detail = "尚未安装 MSF 系统后台"
+    }
+  }
+
+  func install() {
+    guard !isBusy else { return }
+    isBusy = true
+    detail = "正在请求管理员权限…"
+    Task {
+      defer { isBusy = false }
+      do {
+        #if DEBUG
+          let output = try await Self.runLegacyInstaller(action: "install")
+          detail = output.isEmpty ? "后台安装完成，正在等待启动" : output
+        #else
+          if service.status == .enabled {
+            try await service.unregister()
+          }
+          try service.register()
+          if service.status == .requiresApproval {
+            SMAppService.openSystemSettingsLoginItems()
+          }
+        #endif
+        await waitForBackend()
+        await refresh()
+      } catch {
+        state = .failed(error.localizedDescription)
+        detail = error.localizedDescription
+      }
+    }
+  }
+
+  func uninstall() {
+    guard !isBusy else { return }
+    isBusy = true
+    detail = "正在停止并移除系统后台…"
+    Task {
+      defer { isBusy = false }
+      do {
+        #if DEBUG
+          let output = try await Self.runLegacyInstaller(action: "uninstall")
+          detail = output.isEmpty ? "后台已卸载，配置数据已保留" : output
+        #else
+          if service.status != .notRegistered && service.status != .notFound {
+            try await service.unregister()
+          }
+          detail = "后台已取消注册，配置数据已保留"
+        #endif
+        try? await Task.sleep(for: .milliseconds(500))
+        await refresh()
+      } catch {
+        state = .failed(error.localizedDescription)
+        detail = error.localizedDescription
+      }
+    }
+  }
+
+  func openApprovalSettings() {
+    SMAppService.openSystemSettingsLoginItems()
+  }
+
+  private func waitForBackend() async {
+    for _ in 0..<30 {
+      if await backendReachable() { return }
+      try? await Task.sleep(for: .milliseconds(300))
+    }
+  }
+
+  private func backendReachable() async -> Bool {
+    guard let url = URL(string: "http://127.0.0.1:7777/api/v1/version") else {
+      return false
+    }
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 1
+    do {
+      let (_, response) = try await URLSession.shared.data(for: request)
+      guard let http = response as? HTTPURLResponse else { return false }
+      return (200..<300).contains(http.statusCode)
+    } catch {
+      return false
+    }
+  }
+
+  private nonisolated static func runLegacyInstaller(action: String) async throws -> String {
+    guard
+      let script = Bundle.main.path(forResource: "msf-daemon-installer", ofType: "sh")
+    else {
+      throw DaemonServiceError("App 中缺少后台安装器")
+    }
+    let bundlePath = Bundle.main.bundlePath
+    let command = shellQuote(script) + " " + shellQuote(action) + " " + shellQuote(bundlePath)
+    let source = "do shell script " + appleScriptLiteral(command) + " with administrator privileges"
+    return try await Task.detached(priority: .userInitiated) {
+      let process = Process()
+      let output = Pipe()
+      let errorOutput = Pipe()
+      process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+      process.arguments = ["-e", source]
+      process.standardOutput = output
+      process.standardError = errorOutput
+      try process.run()
+      process.waitUntilExit()
+      let stdout =
+        String(
+          data: output.fileHandleForReading.readDataToEndOfFile(),
+          encoding: .utf8
+        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      let stderr =
+        String(
+          data: errorOutput.fileHandleForReading.readDataToEndOfFile(),
+          encoding: .utf8
+        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      guard process.terminationStatus == 0 else {
+        throw DaemonServiceError(stderr.isEmpty ? "管理员授权被取消或安装失败" : stderr)
+      }
+      return stdout
+    }.value
+  }
+
+  private nonisolated static func shellQuote(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+  }
+
+  private nonisolated static func appleScriptLiteral(_ value: String) -> String {
+    let escaped =
+      value
+      .replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "\"", with: "\\\"")
+      .replacingOccurrences(of: "\n", with: "\\n")
+    return "\"" + escaped + "\""
+  }
+}
+
+private struct DaemonServiceError: LocalizedError, Sendable {
+  let message: String
+
+  init(_ message: String) {
+    self.message = message
+  }
+
+  var errorDescription: String? { message }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarApp/MSFMenuBarApp.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarApp/MSFMenuBarApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@main
+@MainActor
+struct MSFMenuBarApp: App {
+  @StateObject private var model = MenuBarModel()
+
+  var body: some Scene {
+    MenuBarExtra {
+      MenuContentView(model: model)
+    } label: {
+      MenuBarLabel(model: model)
+    }
+    .menuBarExtraStyle(.menu)
+
+    Settings {
+      ConnectionSettingsView(model: model)
+    }
+  }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarApp/MenuBarModel.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarApp/MenuBarModel.swift
@@ -1,0 +1,304 @@
+import Foundation
+import MSFMenuBarCore
+import SwiftUI
+
+@MainActor
+final class MenuBarModel: ObservableObject {
+  private enum DefaultsKey {
+    static let baseURL = "msf.baseURL"
+    static let showSpeed = "msf.showSpeedInMenuBar"
+  }
+
+  @Published private(set) var snapshot: RuntimeSnapshot = .offline
+  @Published private(set) var isPerformingAction = false
+  @Published private(set) var isPairing = false
+  @Published private(set) var hasToken = false
+  @Published private(set) var lastError: String?
+  @Published private(set) var baseURLString: String
+  @Published private(set) var showSpeedInMenuBar: Bool
+
+  private let apiClient: any MSFAPIClientProtocol
+  private let tokenStore: KeychainTokenStore
+  private let defaults: UserDefaults
+  private var pollingTask: Task<Void, Never>?
+
+  init(
+    apiClient: any MSFAPIClientProtocol = MSFAPIClient(),
+    tokenStore: KeychainTokenStore = KeychainTokenStore(),
+    defaults: UserDefaults = .standard
+  ) {
+    self.apiClient = apiClient
+    self.tokenStore = tokenStore
+    self.defaults = defaults
+    baseURLString =
+      defaults.string(forKey: DefaultsKey.baseURL)
+      ?? MSFEndpoint.defaultURLString
+    if defaults.object(forKey: DefaultsKey.showSpeed) == nil {
+      showSpeedInMenuBar = true
+    } else {
+      showSpeedInMenuBar = defaults.bool(forKey: DefaultsKey.showSpeed)
+    }
+    hasToken = (try? tokenStore.load())?.isEmpty == false
+    if !hasToken {
+      snapshot = RuntimeSnapshot(
+        phase: .offline,
+        reachable: false,
+        mosdnsRunning: false,
+        mihomoRunning: false,
+        detail: "请在连接设置中绑定后台"
+      )
+    }
+    startPolling()
+  }
+
+  var statusTitle: String {
+    switch snapshot.phase {
+    case .offline:
+      hasToken ? "后台离线" : "尚未连接"
+    case .starting:
+      "正在启动"
+    case .enabled:
+      "运行中"
+    case .direct:
+      "已停止（LAN 直连）"
+    case .restarting:
+      "正在重启"
+    case .degraded:
+      "运行异常"
+    case .stopped:
+      "服务已完全停止"
+    }
+  }
+
+  var statusSymbolName: String {
+    switch snapshot.phase {
+    case .offline:
+      "network.slash"
+    case .starting, .restarting:
+      "arrow.triangle.2.circlepath"
+    case .enabled:
+      "network"
+    case .direct:
+      "arrow.triangle.branch"
+    case .degraded:
+      "exclamationmark.triangle"
+    case .stopped:
+      "pause.circle"
+    }
+  }
+
+  var compactSpeedText: String {
+    let down = SpeedFormatter.string(
+      bytesPerSecond: snapshot.downloadBytesPerSecond,
+      compact: true
+    )
+    let up = SpeedFormatter.string(
+      bytesPerSecond: snapshot.uploadBytesPerSecond,
+      compact: true
+    )
+    return "↓\(down) ↑\(up)"
+  }
+
+  var fullSpeedText: String {
+    let down = SpeedFormatter.string(bytesPerSecond: snapshot.downloadBytesPerSecond)
+    let up = SpeedFormatter.string(bytesPerSecond: snapshot.uploadBytesPerSecond)
+    return "↓ \(down)    ↑ \(up)"
+  }
+
+  var canEnable: Bool {
+    hasToken
+      && !isPerformingAction
+      && snapshot.phase != .enabled
+      && snapshot.phase != .starting
+  }
+
+  var canSafeDisable: Bool {
+    hasToken
+      && !isPerformingAction
+      && snapshot.supportsSafeDisable
+      && snapshot.phase == .enabled
+  }
+
+  var canRestart: Bool {
+    hasToken
+      && !isPerformingAction
+      && snapshot.reachable
+      && snapshot.phase.hasActiveDataPlane
+  }
+
+  var canFullStop: Bool {
+    hasToken
+      && !isPerformingAction
+      && snapshot.reachable
+      && snapshot.phase != .stopped
+  }
+
+  var webURL: URL? {
+    try? MSFEndpoint.normalize(baseURLString)
+  }
+
+  func setShowSpeedInMenuBar(_ enabled: Bool) {
+    showSpeedInMenuBar = enabled
+    defaults.set(enabled, forKey: DefaultsKey.showSpeed)
+  }
+
+  func saveBaseURL(_ value: String) -> Bool {
+    do {
+      let url = try MSFEndpoint.normalize(value)
+      baseURLString = url.absoluteString
+      defaults.set(baseURLString, forKey: DefaultsKey.baseURL)
+      lastError = nil
+      restartPolling()
+      return true
+    } catch {
+      lastError = error.localizedDescription
+      return false
+    }
+  }
+
+  func pair(baseURL value: String, username: String, password: String) async -> Bool {
+    guard !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+      !password.isEmpty
+    else {
+      lastError = "请输入管理员用户名和密码"
+      return false
+    }
+
+    isPairing = true
+    defer { isPairing = false }
+    do {
+      let url = try MSFEndpoint.normalize(value)
+      let token = try await apiClient.pair(
+        baseURL: url,
+        username: username.trimmingCharacters(in: .whitespacesAndNewlines),
+        password: password
+      )
+      try tokenStore.save(token)
+      baseURLString = url.absoluteString
+      defaults.set(baseURLString, forKey: DefaultsKey.baseURL)
+      hasToken = true
+      lastError = nil
+      await refresh()
+      return true
+    } catch {
+      lastError = error.localizedDescription
+      return false
+    }
+  }
+
+  func saveManualToken(baseURL value: String, token rawToken: String) async -> Bool {
+    let token = rawToken.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !token.isEmpty else {
+      lastError = "API Token 不能为空"
+      return false
+    }
+    do {
+      let url = try MSFEndpoint.normalize(value)
+      try tokenStore.save(token)
+      baseURLString = url.absoluteString
+      defaults.set(baseURLString, forKey: DefaultsKey.baseURL)
+      hasToken = true
+      lastError = nil
+      await refresh()
+      return snapshot.reachable
+    } catch {
+      lastError = error.localizedDescription
+      return false
+    }
+  }
+
+  func disconnect() {
+    do {
+      try tokenStore.delete()
+      hasToken = false
+      lastError = nil
+      snapshot = RuntimeSnapshot(
+        phase: .offline,
+        reachable: false,
+        mosdnsRunning: false,
+        mihomoRunning: false,
+        detail: "请在连接设置中绑定后台"
+      )
+    } catch {
+      lastError = error.localizedDescription
+    }
+  }
+
+  func perform(_ action: RuntimeAction) {
+    guard !isPerformingAction else { return }
+    Task { @MainActor [weak self] in
+      await self?.performNow(action)
+    }
+  }
+
+  func refresh() async {
+    guard hasToken else { return }
+    do {
+      let configuration = try currentConfiguration()
+      snapshot = try await apiClient.snapshot(configuration: configuration)
+      lastError = nil
+    } catch {
+      snapshot = RuntimeSnapshot(
+        phase: .offline,
+        reachable: false,
+        mosdnsRunning: false,
+        mihomoRunning: false,
+        detail: error.localizedDescription
+      )
+      lastError = error.localizedDescription
+    }
+  }
+
+  private func performNow(_ action: RuntimeAction) async {
+    isPerformingAction = true
+    lastError = nil
+    let previousPhase = snapshot.phase
+    switch action {
+    case .enable:
+      snapshot.phase = .starting
+    case .restart:
+      snapshot.phase = .restarting
+    case .disable, .fullStop:
+      break
+    }
+
+    do {
+      let configuration = try currentConfiguration()
+      try await apiClient.perform(action, configuration: configuration)
+      try? await Task.sleep(for: .milliseconds(400))
+      await refresh()
+    } catch {
+      snapshot.phase = previousPhase
+      lastError = error.localizedDescription
+    }
+    isPerformingAction = false
+  }
+
+  private func currentConfiguration() throws -> APIConfiguration {
+    let baseURL = try MSFEndpoint.normalize(baseURLString)
+    guard let token = try tokenStore.load(), !token.isEmpty else {
+      throw MSFAPIError.missingToken
+    }
+    return APIConfiguration(baseURL: baseURL, token: token)
+  }
+
+  private func startPolling() {
+    pollingTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        guard let self else { return }
+        await refresh()
+        let interval: Duration = showSpeedInMenuBar ? .seconds(1) : .seconds(5)
+        do {
+          try await Task.sleep(for: interval)
+        } catch {
+          return
+        }
+      }
+    }
+  }
+
+  private func restartPolling() {
+    pollingTask?.cancel()
+    startPolling()
+  }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarApp/MenuBarViews.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarApp/MenuBarViews.swift
@@ -1,0 +1,105 @@
+import AppKit
+import MSFMenuBarCore
+import SwiftUI
+
+struct MenuBarLabel: View {
+  @ObservedObject var model: MenuBarModel
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Image(systemName: model.statusSymbolName)
+      if model.showSpeedInMenuBar {
+        Text(model.compactSpeedText)
+          .monospacedDigit()
+      }
+    }
+    .accessibilityLabel("MSF，\(model.statusTitle)，\(model.fullSpeedText)")
+  }
+}
+
+struct MenuContentView: View {
+  @ObservedObject var model: MenuBarModel
+
+  var body: some View {
+    Text(model.statusTitle)
+
+    Text(model.fullSpeedText)
+      .monospacedDigit()
+
+    if let detail = model.snapshot.detail, !detail.isEmpty {
+      Text(detail)
+    }
+    if let error = model.lastError, error != model.snapshot.detail {
+      Text(error)
+    }
+
+    Divider()
+
+    Button("启动", systemImage: "play.fill") {
+      model.perform(.enable)
+    }
+    .disabled(!model.canEnable)
+
+    Button("停止（LAN 直连保活）", systemImage: "stop.fill") {
+      model.perform(.disable)
+    }
+    .disabled(!model.canSafeDisable)
+
+    if model.snapshot.reachable, !model.snapshot.supportsSafeDisable {
+      Text("安全停止需要新版 TUN Runtime API")
+    }
+
+    Button("重启", systemImage: "arrow.clockwise") {
+      model.perform(.restart)
+    }
+    .disabled(!model.canRestart)
+
+    Button("完全停止服务…", systemImage: "power", role: .destructive) {
+      confirmFullStop()
+    }
+    .disabled(!model.canFullStop)
+
+    Divider()
+
+    Button("打开网页管理页", systemImage: "safari") {
+      openWebManagement()
+    }
+
+    SettingsLink {
+      Label("连接设置…", systemImage: "gearshape")
+    }
+
+    Toggle(
+      "菜单栏显示速度",
+      isOn: Binding(
+        get: { model.showSpeedInMenuBar },
+        set: { model.setShowSpeedInMenuBar($0) }
+      )
+    )
+
+    Divider()
+
+    Button("退出 MSF 菜单栏", systemImage: "xmark") {
+      NSApplication.shared.terminate(nil)
+    }
+    .keyboardShortcut("q")
+  }
+
+  private func openWebManagement() {
+    guard let url = model.webURL else { return }
+    NSWorkspace.shared.open(url)
+  }
+
+  private func confirmFullStop() {
+    let alert = NSAlert()
+    alert.alertStyle = .warning
+    alert.messageText = "完全停止 MSF 服务？"
+    alert.informativeText =
+      "这会停止 MosDNS、Mihomo 并拆除 TUN。若主路由仍把 DNS 和 Fake-IP 路由指向这台 Mac，局域网设备可能立即断流。"
+    alert.addButton(withTitle: "完全停止")
+    alert.addButton(withTitle: "取消")
+    if alert.runModal() == .alertFirstButtonReturn {
+      model.perform(.fullStop)
+    }
+  }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarCore/Endpoint.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarCore/Endpoint.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public enum MSFEndpoint {
+  public static let defaultURLString = "http://127.0.0.1:7777"
+
+  public static func normalize(_ rawValue: String) throws -> URL {
+    var value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    if value.isEmpty {
+      value = defaultURLString
+    }
+    if !value.contains("://") {
+      value = "http://" + value
+    }
+
+    guard var components = URLComponents(string: value),
+      let scheme = components.scheme?.lowercased(),
+      scheme == "http" || scheme == "https",
+      components.host?.isEmpty == false
+    else {
+      throw MSFAPIError.invalidBaseURL
+    }
+
+    components.scheme = scheme
+    components.query = nil
+    components.fragment = nil
+    if components.path == "/" {
+      components.path = ""
+    } else {
+      while components.path.hasSuffix("/") {
+        components.path.removeLast()
+      }
+    }
+
+    guard let url = components.url else {
+      throw MSFAPIError.invalidBaseURL
+    }
+    return url
+  }
+
+  public static func apiURL(baseURL: URL, path: String) throws -> URL {
+    let cleanPath = path.hasPrefix("/") ? path : "/" + path
+    guard let url = URL(string: baseURL.absoluteString + cleanPath) else {
+      throw MSFAPIError.invalidBaseURL
+    }
+    return url
+  }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarCore/KeychainTokenStore.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarCore/KeychainTokenStore.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Security
+
+public struct KeychainTokenStore: Sendable {
+  public let service: String
+  public let account: String
+
+  public init(
+    service: String = "io.github.scoltzero.msf.menubar",
+    account: String = "api-token"
+  ) {
+    self.service = service
+    self.account = account
+  }
+
+  public func load() throws -> String? {
+    for useDataProtection in [true, false] {
+      var query = baseQuery(useDataProtection: useDataProtection)
+      query[kSecReturnData as String] = true
+      query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+      var result: CFTypeRef?
+      let status = SecItemCopyMatching(query as CFDictionary, &result)
+      if status == errSecItemNotFound || (useDataProtection && status == errSecMissingEntitlement) {
+        continue
+      }
+      guard status == errSecSuccess,
+        let data = result as? Data,
+        let token = String(data: data, encoding: .utf8)
+      else {
+        throw KeychainError(status: status)
+      }
+      return token
+    }
+    return nil
+  }
+
+  public func save(_ token: String) throws {
+    let data = Data(token.utf8)
+    for useDataProtection in [true, false] {
+      let status = save(data, useDataProtection: useDataProtection)
+      if status == errSecSuccess {
+        return
+      }
+      if useDataProtection && status == errSecMissingEntitlement {
+        continue
+      }
+      throw KeychainError(status: status)
+    }
+    throw KeychainError(status: errSecMissingEntitlement)
+  }
+
+  public func delete() throws {
+    var firstError: OSStatus?
+    for useDataProtection in [true, false] {
+      let status = SecItemDelete(baseQuery(useDataProtection: useDataProtection) as CFDictionary)
+      if status == errSecSuccess || status == errSecItemNotFound
+        || (useDataProtection && status == errSecMissingEntitlement)
+      {
+        continue
+      }
+      if firstError == nil {
+        firstError = status
+      }
+    }
+    if let firstError {
+      throw KeychainError(status: firstError)
+    }
+  }
+
+  private func save(_ data: Data, useDataProtection: Bool) -> OSStatus {
+    let query = baseQuery(useDataProtection: useDataProtection)
+    let updateStatus = SecItemUpdate(
+      query as CFDictionary,
+      [kSecValueData as String: data] as CFDictionary
+    )
+    if updateStatus == errSecSuccess || updateStatus != errSecItemNotFound {
+      return updateStatus
+    }
+
+    var attributes = query
+    attributes[kSecValueData as String] = data
+    return SecItemAdd(attributes as CFDictionary, nil)
+  }
+
+  private func baseQuery(useDataProtection: Bool) -> [String: Any] {
+    var query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account,
+    ]
+    if useDataProtection {
+      query[kSecUseDataProtectionKeychain as String] = true
+    }
+    return query
+  }
+}
+
+public struct KeychainError: LocalizedError, Equatable, Sendable {
+  public let status: OSStatus
+
+  public init(status: OSStatus) {
+    self.status = status
+  }
+
+  public var errorDescription: String? {
+    if let message = SecCopyErrorMessageString(status, nil) as String? {
+      return "Keychain：\(message)"
+    }
+    return "Keychain 错误（\(status)）"
+  }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarCore/MSFAPIClient.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarCore/MSFAPIClient.swift
@@ -1,0 +1,202 @@
+import Foundation
+
+public protocol MSFAPIClientProtocol: Sendable {
+  func snapshot(configuration: APIConfiguration) async throws -> RuntimeSnapshot
+  func perform(_ action: RuntimeAction, configuration: APIConfiguration) async throws
+  func pair(baseURL: URL, username: String, password: String) async throws -> String
+}
+
+public actor MSFAPIClient: MSFAPIClientProtocol {
+  private let session: URLSession
+
+  public init(session: URLSession = .shared) {
+    self.session = session
+  }
+
+  public func snapshot(configuration: APIConfiguration) async throws -> RuntimeSnapshot {
+    do {
+      let payload = try await requestJSON(
+        baseURL: configuration.baseURL,
+        path: "/api/v1/network/runtime",
+        token: configuration.token
+      )
+      guard let snapshot = PayloadParser.runtimeSnapshot(from: payload) else {
+        throw MSFAPIError.invalidResponse
+      }
+      return snapshot
+    } catch MSFAPIError.notFound {
+      let services = try await requestJSON(
+        baseURL: configuration.baseURL,
+        path: "/api/v1/services",
+        token: configuration.token
+      )
+      let traffic = try await requestJSON(
+        baseURL: configuration.baseURL,
+        path: "/api/v1/mihomo/traffic?fresh=1",
+        token: configuration.token
+      )
+      return PayloadParser.legacySnapshot(
+        servicesPayload: services,
+        trafficPayload: traffic
+      )
+    }
+  }
+
+  public func perform(_ action: RuntimeAction, configuration: APIConfiguration) async throws {
+    let endpoint: String
+    switch action {
+    case .enable:
+      endpoint = "/api/v1/network/runtime/enable"
+    case .disable:
+      endpoint = "/api/v1/network/runtime/disable"
+    case .restart:
+      endpoint = "/api/v1/network/runtime/restart"
+    case .fullStop:
+      endpoint = "/api/v1/network/runtime/stop"
+    }
+
+    do {
+      _ = try await requestJSON(
+        baseURL: configuration.baseURL,
+        path: endpoint,
+        method: "POST",
+        token: configuration.token
+      )
+      return
+    } catch MSFAPIError.notFound {
+      switch action {
+      case .enable:
+        try await performLegacy(
+          path: "/api/v1/services/start-all?wait=1&timeout_ms=10000",
+          configuration: configuration
+        )
+      case .restart:
+        try await performLegacy(
+          path: "/api/v1/services/restart-all?wait=1&timeout_ms=10000",
+          configuration: configuration
+        )
+      case .fullStop:
+        try await performLegacy(
+          path: "/api/v1/services/stop-all?wait=1&timeout_ms=10000",
+          configuration: configuration
+        )
+      case .disable:
+        throw MSFAPIError.safeDisableUnsupported
+      }
+    }
+  }
+
+  public func pair(baseURL: URL, username: String, password: String) async throws -> String {
+    let loginPayload = try await requestJSON(
+      baseURL: baseURL,
+      path: "/api/v1/auth/login",
+      method: "POST",
+      body: [
+        "username": username,
+        "password": password,
+      ]
+    )
+    guard let loginToken = loginPayload["token"] as? String, !loginToken.isEmpty else {
+      throw MSFAPIError.invalidResponse
+    }
+
+    let hostName = Host.current().localizedName ?? "macOS"
+    let tokenPayload = try await requestJSON(
+      baseURL: baseURL,
+      path: "/api/v1/api-tokens",
+      method: "POST",
+      token: loginToken,
+      body: [
+        "name": "MSF Menu Bar - \(hostName)",
+        "scope": "operate",
+      ]
+    )
+    guard let apiToken = tokenPayload["token"] as? String, !apiToken.isEmpty else {
+      throw MSFAPIError.invalidResponse
+    }
+    return apiToken
+  }
+
+  private func performLegacy(path: String, configuration: APIConfiguration) async throws {
+    let payload = try await requestJSON(
+      baseURL: configuration.baseURL,
+      path: path,
+      method: "POST",
+      token: configuration.token
+    )
+    if let success = payload["success"] as? Bool, !success {
+      throw MSFAPIError.server(errorMessage(from: payload))
+    }
+  }
+
+  private func requestJSON(
+    baseURL: URL,
+    path: String,
+    method: String = "GET",
+    token: String? = nil,
+    body: [String: Any]? = nil
+  ) async throws -> [String: Any] {
+    let url = try MSFEndpoint.apiURL(baseURL: baseURL, path: path)
+    var request = URLRequest(url: url)
+    request.httpMethod = method
+    request.timeoutInterval = 15
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    if let token, !token.isEmpty {
+      request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+    if let body {
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      do {
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+      } catch {
+        throw MSFAPIError.invalidResponse
+      }
+    }
+
+    let data: Data
+    let response: URLResponse
+    do {
+      (data, response) = try await session.data(for: request)
+    } catch {
+      throw MSFAPIError.transport(error.localizedDescription)
+    }
+
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw MSFAPIError.invalidResponse
+    }
+    if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+      throw MSFAPIError.unauthorized
+    }
+    if httpResponse.statusCode == 404 {
+      throw MSFAPIError.notFound
+    }
+
+    let payload: [String: Any]
+    if data.isEmpty {
+      payload = [:]
+    } else {
+      do {
+        payload = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+      } catch {
+        throw MSFAPIError.invalidResponse
+      }
+    }
+    guard (200..<300).contains(httpResponse.statusCode) else {
+      throw MSFAPIError.server(errorMessage(from: payload))
+    }
+    if let success = payload["success"] as? Bool, !success {
+      throw MSFAPIError.server(errorMessage(from: payload))
+    }
+    return payload
+  }
+
+  private func errorMessage(from payload: [String: Any]) -> String {
+    if let message = payload["message"] as? String, !message.isEmpty {
+      return message
+    }
+    if let error = payload["error"] as? String, !error.isEmpty {
+      return error
+    }
+    return "后台操作失败"
+  }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarCore/PayloadParser.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarCore/PayloadParser.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+enum PayloadParser {
+  static func runtimeSnapshot(from payload: [String: Any]) -> RuntimeSnapshot? {
+    let root = dictionary(payload["data"]) ?? payload
+    guard
+      let rawState = string(root["effective_state"])
+        ?? string(root["state"])
+        ?? string(root["status"])
+    else {
+      return nil
+    }
+
+    let services = dictionary(root["services"])
+    let mosdns = serviceRunning(named: "mosdns", root: root, services: services)
+    let mihomo = serviceRunning(named: "mihomo", root: root, services: services)
+    let traffic = dictionary(root["traffic"]) ?? dictionary(root["network"]) ?? root
+
+    return RuntimeSnapshot(
+      phase: RuntimePhase(serverValue: rawState),
+      reachable: true,
+      mosdnsRunning: mosdns,
+      mihomoRunning: mihomo,
+      downloadBytesPerSecond: number(traffic["down_bps"])
+        ?? number(traffic["download_speed"])
+        ?? number(traffic["down"])
+        ?? number(traffic["download"])
+        ?? 0,
+      uploadBytesPerSecond: number(traffic["up_bps"])
+        ?? number(traffic["upload_speed"])
+        ?? number(traffic["up"])
+        ?? number(traffic["upload"])
+        ?? 0,
+      supportsSafeDisable: true,
+      detail: string(root["message"]) ?? string(root["last_error"])
+    )
+  }
+
+  static func legacySnapshot(
+    servicesPayload: [String: Any],
+    trafficPayload: [String: Any]
+  ) -> RuntimeSnapshot {
+    let serviceRows =
+      array(servicesPayload["data"])
+      ?? array(servicesPayload["services"])
+      ?? []
+    var mosdns = false
+    var mihomo = false
+    for item in serviceRows {
+      guard let row = dictionary(item), let name = string(row["name"])?.lowercased() else {
+        continue
+      }
+      let running =
+        bool(row["running"])
+        ?? (string(row["status"])?.lowercased() == "running")
+      if name == "mosdns" {
+        mosdns = running
+      } else if name == "mihomo" || name == "proxy" || name == "clash" {
+        mihomo = running
+      }
+    }
+
+    let phase: RuntimePhase
+    if mosdns && mihomo {
+      phase = .enabled
+    } else if !mosdns && !mihomo {
+      phase = .stopped
+    } else {
+      phase = .degraded
+    }
+
+    let traffic = dictionary(trafficPayload["data"]) ?? trafficPayload
+    return RuntimeSnapshot(
+      phase: phase,
+      reachable: true,
+      mosdnsRunning: mosdns,
+      mihomoRunning: mihomo,
+      downloadBytesPerSecond: number(traffic["down"])
+        ?? number(traffic["download"])
+        ?? number(traffic["download_speed"])
+        ?? 0,
+      uploadBytesPerSecond: number(traffic["up"])
+        ?? number(traffic["upload"])
+        ?? number(traffic["upload_speed"])
+        ?? 0,
+      supportsSafeDisable: false,
+      detail: "兼容旧版后台"
+    )
+  }
+
+  private static func serviceRunning(
+    named name: String,
+    root: [String: Any],
+    services: [String: Any]?
+  ) -> Bool {
+    if let directValue = bool(root[name + "_running"]) {
+      return directValue
+    }
+    if let service = dictionary(services?[name]) {
+      return bool(service["running"])
+        ?? (string(service["status"])?.lowercased() == "running")
+    }
+    return false
+  }
+
+  private static func dictionary(_ value: Any?) -> [String: Any]? {
+    value as? [String: Any]
+  }
+
+  private static func array(_ value: Any?) -> [Any]? {
+    value as? [Any]
+  }
+
+  private static func string(_ value: Any?) -> String? {
+    if let value = value as? String, !value.isEmpty {
+      return value
+    }
+    return nil
+  }
+
+  private static func bool(_ value: Any?) -> Bool? {
+    if let value = value as? Bool {
+      return value
+    }
+    if let value = value as? NSNumber {
+      return value.boolValue
+    }
+    if let value = value as? String {
+      switch value.lowercased() {
+      case "true", "1", "yes", "running", "active":
+        return true
+      case "false", "0", "no", "stopped", "inactive":
+        return false
+      default:
+        return nil
+      }
+    }
+    return nil
+  }
+
+  private static func number(_ value: Any?) -> Double? {
+    if let value = value as? Double {
+      return value
+    }
+    if let value = value as? NSNumber {
+      return value.doubleValue
+    }
+    if let value = value as? String {
+      return Double(value)
+    }
+    return nil
+  }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarCore/RuntimeModels.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarCore/RuntimeModels.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+public enum RuntimePhase: String, Codable, CaseIterable, Sendable {
+  case offline
+  case starting
+  case enabled
+  case direct
+  case restarting
+  case degraded
+  case stopped
+
+  public init(serverValue: String) {
+    switch serverValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "starting":
+      self = .starting
+    case "enabled", "running", "active", "rule":
+      self = .enabled
+    case "direct", "disabled", "bypass":
+      self = .direct
+    case "restarting":
+      self = .restarting
+    case "degraded", "error", "failed":
+      self = .degraded
+    case "stopped", "inactive":
+      self = .stopped
+    default:
+      self = .offline
+    }
+  }
+
+  public var isBusy: Bool {
+    self == .starting || self == .restarting
+  }
+
+  public var hasActiveDataPlane: Bool {
+    switch self {
+    case .enabled, .direct, .starting, .restarting, .degraded:
+      true
+    case .offline, .stopped:
+      false
+    }
+  }
+}
+
+public enum RuntimeAction: String, Sendable {
+  case enable
+  case disable
+  case restart
+  case fullStop
+}
+
+public struct RuntimeSnapshot: Equatable, Sendable {
+  public var phase: RuntimePhase
+  public var reachable: Bool
+  public var mosdnsRunning: Bool
+  public var mihomoRunning: Bool
+  public var downloadBytesPerSecond: Double
+  public var uploadBytesPerSecond: Double
+  public var supportsSafeDisable: Bool
+  public var detail: String?
+
+  public init(
+    phase: RuntimePhase,
+    reachable: Bool,
+    mosdnsRunning: Bool,
+    mihomoRunning: Bool,
+    downloadBytesPerSecond: Double = 0,
+    uploadBytesPerSecond: Double = 0,
+    supportsSafeDisable: Bool = false,
+    detail: String? = nil
+  ) {
+    self.phase = phase
+    self.reachable = reachable
+    self.mosdnsRunning = mosdnsRunning
+    self.mihomoRunning = mihomoRunning
+    self.downloadBytesPerSecond = max(0, downloadBytesPerSecond)
+    self.uploadBytesPerSecond = max(0, uploadBytesPerSecond)
+    self.supportsSafeDisable = supportsSafeDisable
+    self.detail = detail
+  }
+
+  public static let offline = RuntimeSnapshot(
+    phase: .offline,
+    reachable: false,
+    mosdnsRunning: false,
+    mihomoRunning: false,
+    detail: "无法连接后台"
+  )
+}
+
+public struct APIConfiguration: Equatable, Sendable {
+  public let baseURL: URL
+  public let token: String
+
+  public init(baseURL: URL, token: String) {
+    self.baseURL = baseURL
+    self.token = token
+  }
+}
+
+public enum MSFAPIError: Error, Equatable, Sendable {
+  case invalidBaseURL
+  case missingToken
+  case unauthorized
+  case notFound
+  case safeDisableUnsupported
+  case invalidResponse
+  case server(String)
+  case transport(String)
+}
+
+extension MSFAPIError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .invalidBaseURL:
+      "后台地址无效"
+    case .missingToken:
+      "尚未配置 API Token"
+    case .unauthorized:
+      "认证失败，请重新连接后台"
+    case .notFound:
+      "后台不支持该接口"
+    case .safeDisableUnsupported:
+      "当前后台版本尚不支持 LAN 直连保活，请升级后台或使用“完全停止服务”"
+    case .invalidResponse:
+      "后台返回了无法识别的数据"
+    case .server(let message):
+      message
+    case .transport(let message):
+      message
+    }
+  }
+}

--- a/macos/MSFMenuBar/Sources/MSFMenuBarCore/SpeedFormatter.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarCore/SpeedFormatter.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum SpeedFormatter {
+  private static let units = ["B/s", "KB/s", "MB/s", "GB/s", "TB/s"]
+  private static let compactUnits = ["B", "K", "M", "G", "T"]
+
+  public static func string(bytesPerSecond rawValue: Double, compact: Bool = false) -> String {
+    var value = rawValue.isFinite ? max(0, rawValue) : 0
+    var unitIndex = 0
+    while value >= 1024, unitIndex < units.count - 1 {
+      value /= 1024
+      unitIndex += 1
+    }
+
+    let number: String
+    if unitIndex == 0 || value >= 100 {
+      number = String(format: "%.0f", value)
+    } else if value >= 10 {
+      number = String(format: "%.1f", value)
+    } else {
+      number = String(format: "%.2f", value)
+    }
+
+    return number + " " + (compact ? compactUnits[unitIndex] : units[unitIndex])
+  }
+}

--- a/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/EndpointTests.swift
+++ b/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/EndpointTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+@testable import MSFMenuBarCore
+
+final class EndpointTests: XCTestCase {
+  func testNormalizeAddsHTTPAndRemovesTrailingSlash() throws {
+    let url = try MSFEndpoint.normalize("127.0.0.1:7777/")
+    XCTAssertEqual(url.absoluteString, "http://127.0.0.1:7777")
+  }
+
+  func testNormalizePreservesBasePath() throws {
+    let url = try MSFEndpoint.normalize("https://example.test/msf/")
+    XCTAssertEqual(url.absoluteString, "https://example.test/msf")
+    XCTAssertEqual(
+      try MSFEndpoint.apiURL(baseURL: url, path: "/api/v1/services").absoluteString,
+      "https://example.test/msf/api/v1/services"
+    )
+  }
+
+  func testNormalizeRejectsUnsupportedScheme() {
+    XCTAssertThrowsError(try MSFEndpoint.normalize("file:///tmp/msf"))
+  }
+}

--- a/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/KeychainTokenStoreTests.swift
+++ b/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/KeychainTokenStoreTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import XCTest
+
+@testable import MSFMenuBarCore
+
+final class KeychainTokenStoreTests: XCTestCase {
+  func testRoundTripWorksWithoutDataProtectionEntitlement() throws {
+    let store = KeychainTokenStore(
+      service: "io.github.scoltzero.msf.menubar.tests.\(UUID().uuidString)",
+      account: "api-token"
+    )
+    defer { try? store.delete() }
+
+    XCTAssertNil(try store.load())
+    try store.save("msf_test_token")
+    XCTAssertEqual(try store.load(), "msf_test_token")
+
+    try store.save("msf_replaced_token")
+    XCTAssertEqual(try store.load(), "msf_replaced_token")
+
+    try store.delete()
+    XCTAssertNil(try store.load())
+  }
+}

--- a/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/MSFAPIClientTests.swift
+++ b/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/MSFAPIClientTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import XCTest
+
+@testable import MSFMenuBarCore
+
+final class MSFAPIClientTests: XCTestCase {
+  override func tearDown() {
+    StubURLProtocol.handler = nil
+    StubURLProtocol.resetRequests()
+    super.tearDown()
+  }
+
+  func testSnapshotFallsBackToLegacyEndpoints() async throws {
+    StubURLProtocol.handler = { request in
+      switch request.url?.path {
+      case "/api/v1/network/runtime":
+        return (404, [:])
+      case "/api/v1/services":
+        return (
+          200,
+          [
+            "success": true,
+            "data": [
+              ["name": "mosdns", "running": true],
+              ["name": "mihomo", "running": true],
+            ],
+          ]
+        )
+      case "/api/v1/mihomo/traffic":
+        return (200, ["success": true, "data": ["down": 4096, "up": 1024]])
+      default:
+        return (500, ["error": "unexpected endpoint"])
+      }
+    }
+
+    let snapshot = try await makeClient().snapshot(configuration: configuration)
+    XCTAssertEqual(snapshot.phase, .enabled)
+    XCTAssertEqual(snapshot.downloadBytesPerSecond, 4096)
+    XCTAssertEqual(snapshot.uploadBytesPerSecond, 1024)
+    XCTAssertFalse(snapshot.supportsSafeDisable)
+  }
+
+  func testSafeDisableNeverFallsBackToStopAll() async {
+    StubURLProtocol.handler = { request in
+      if request.url?.path == "/api/v1/network/runtime/disable" {
+        return (404, [:])
+      }
+      return (500, ["error": "unexpected endpoint"])
+    }
+
+    do {
+      try await makeClient().perform(.disable, configuration: configuration)
+      XCTFail("safe disable should fail when the unified runtime endpoint is unavailable")
+    } catch {
+      XCTAssertEqual(error as? MSFAPIError, .safeDisableUnsupported)
+    }
+
+    XCTAssertFalse(
+      StubURLProtocol.requests().contains { $0.contains("/api/v1/services/stop-all") }
+    )
+  }
+
+  func testEnableFallsBackToLegacyStartAll() async throws {
+    StubURLProtocol.handler = { request in
+      switch request.url?.path {
+      case "/api/v1/network/runtime/enable":
+        return (404, [:])
+      case "/api/v1/services/start-all":
+        return (200, ["success": true])
+      default:
+        return (500, ["error": "unexpected endpoint"])
+      }
+    }
+
+    try await makeClient().perform(.enable, configuration: configuration)
+    XCTAssertTrue(
+      StubURLProtocol.requests().contains { $0.contains("/api/v1/services/start-all") }
+    )
+  }
+
+  private var configuration: APIConfiguration {
+    APIConfiguration(baseURL: URL(string: "http://127.0.0.1:7777")!, token: "msf_test")
+  }
+
+  private func makeClient() -> MSFAPIClient {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StubURLProtocol.self]
+    return MSFAPIClient(session: URLSession(configuration: configuration))
+  }
+}
+
+private final class StubURLProtocol: URLProtocol, @unchecked Sendable {
+  nonisolated(unsafe) static var handler: ((URLRequest) -> (Int, [String: Any]))?
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var recordedRequests: [String] = []
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    let requestURL = request.url?.absoluteString ?? ""
+    Self.lock.lock()
+    Self.recordedRequests.append(requestURL)
+    let handler = Self.handler
+    Self.lock.unlock()
+
+    guard let handler, let url = request.url else {
+      client?.urlProtocol(self, didFailWithError: MSFAPIError.invalidResponse)
+      return
+    }
+
+    let (statusCode, payload) = handler(request)
+    let response = HTTPURLResponse(
+      url: url,
+      statusCode: statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: ["Content-Type": "application/json"]
+    )!
+    let data = try! JSONSerialization.data(withJSONObject: payload)
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: data)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+
+  static func requests() -> [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recordedRequests
+  }
+
+  static func resetRequests() {
+    lock.lock()
+    recordedRequests.removeAll()
+    lock.unlock()
+  }
+}

--- a/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/PayloadParserTests.swift
+++ b/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/PayloadParserTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+@testable import MSFMenuBarCore
+
+final class PayloadParserTests: XCTestCase {
+  func testParsesUnifiedRuntimePayload() throws {
+    let payload: [String: Any] = [
+      "data": [
+        "effective_state": "enabled",
+        "services": [
+          "mosdns": ["running": true],
+          "mihomo": ["running": true],
+        ],
+        "traffic": [
+          "down_bps": 2_048,
+          "up_bps": 1_024,
+        ],
+      ]
+    ]
+
+    let snapshot = try XCTUnwrap(PayloadParser.runtimeSnapshot(from: payload))
+    XCTAssertEqual(snapshot.phase, .enabled)
+    XCTAssertTrue(snapshot.reachable)
+    XCTAssertTrue(snapshot.mosdnsRunning)
+    XCTAssertTrue(snapshot.mihomoRunning)
+    XCTAssertEqual(snapshot.downloadBytesPerSecond, 2_048)
+    XCTAssertEqual(snapshot.uploadBytesPerSecond, 1_024)
+    XCTAssertTrue(snapshot.supportsSafeDisable)
+  }
+
+  func testParsesLegacyServicesAndTraffic() {
+    let services: [String: Any] = [
+      "data": [
+        ["name": "mosdns", "running": true],
+        ["name": "mihomo", "status": "running"],
+      ]
+    ]
+    let traffic: [String: Any] = [
+      "data": ["down": 4_096, "up": 512]
+    ]
+
+    let snapshot = PayloadParser.legacySnapshot(
+      servicesPayload: services,
+      trafficPayload: traffic
+    )
+    XCTAssertEqual(snapshot.phase, .enabled)
+    XCTAssertEqual(snapshot.downloadBytesPerSecond, 4_096)
+    XCTAssertEqual(snapshot.uploadBytesPerSecond, 512)
+    XCTAssertFalse(snapshot.supportsSafeDisable)
+  }
+
+  func testLegacyPartialServiceStateIsDegraded() {
+    let snapshot = PayloadParser.legacySnapshot(
+      servicesPayload: [
+        "services": [
+          ["name": "mosdns", "running": true],
+          ["name": "mihomo", "running": false],
+        ]
+      ],
+      trafficPayload: [:]
+    )
+    XCTAssertEqual(snapshot.phase, .degraded)
+  }
+}

--- a/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/SpeedFormatterTests.swift
+++ b/macos/MSFMenuBar/Tests/MSFMenuBarCoreTests/SpeedFormatterTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+@testable import MSFMenuBarCore
+
+final class SpeedFormatterTests: XCTestCase {
+  func testFormatsIdleSpeed() {
+    XCTAssertEqual(SpeedFormatter.string(bytesPerSecond: 0), "0 B/s")
+  }
+
+  func testFormatsBinaryUnits() {
+    XCTAssertEqual(SpeedFormatter.string(bytesPerSecond: 1_024), "1.00 KB/s")
+    XCTAssertEqual(SpeedFormatter.string(bytesPerSecond: 1_572_864), "1.50 MB/s")
+    XCTAssertEqual(
+      SpeedFormatter.string(bytesPerSecond: 1_572_864, compact: true),
+      "1.50 M"
+    )
+  }
+
+  func testClampsInvalidValues() {
+    XCTAssertEqual(SpeedFormatter.string(bytesPerSecond: -.infinity), "0 B/s")
+    XCTAssertEqual(SpeedFormatter.string(bytesPerSecond: -100), "0 B/s")
+  }
+}

--- a/macos/MSFMenuBar/project.yml
+++ b/macos/MSFMenuBar/project.yml
@@ -1,0 +1,73 @@
+name: MSFMenuBar
+
+options:
+  minimumXcodeGenVersion: 2.45.0
+  deploymentTarget:
+    macOS: "15.0"
+  createIntermediateGroups: true
+
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    SWIFT_STRICT_CONCURRENCY: complete
+    MACOSX_DEPLOYMENT_TARGET: "15.0"
+    CLANG_ENABLE_MODULES: YES
+
+targets:
+  MSFMenuBarCore:
+    type: framework
+    platform: macOS
+    sources:
+      - Sources/MSFMenuBarCore
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: io.github.scoltzero.msf.menubar.core
+        GENERATE_INFOPLIST_FILE: YES
+        SKIP_INSTALL: YES
+
+  MSFMenuBar:
+    type: application
+    platform: macOS
+    sources:
+      - Sources/MSFMenuBarApp
+    dependencies:
+      - target: MSFMenuBarCore
+    settings:
+      base:
+        PRODUCT_NAME: MSF
+        PRODUCT_BUNDLE_IDENTIFIER: io.github.scoltzero.msf.menubar
+        MARKETING_VERSION: 0.4.0
+        CURRENT_PROJECT_VERSION: 1
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_CFBundleDisplayName: MSF
+        INFOPLIST_KEY_LSUIElement: YES
+        ENABLE_HARDENED_RUNTIME: YES
+        ENABLE_USER_SCRIPT_SANDBOXING: NO
+        CODE_SIGN_STYLE: Automatic
+    postBuildScripts:
+      - name: Embed Universal MSF Daemon
+        basedOnDependencyAnalysis: false
+        script: |
+          /bin/zsh "$SRCROOT/Scripts/embed-daemon.sh"
+
+  MSFMenuBarCoreTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - Tests/MSFMenuBarCoreTests
+    dependencies:
+      - target: MSFMenuBarCore
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: io.github.scoltzero.msf.menubar.tests
+        GENERATE_INFOPLIST_FILE: YES
+
+schemes:
+  MSFMenuBar:
+    build:
+      targets:
+        MSFMenuBar: all
+        MSFMenuBarCoreTests: [test]
+    test:
+      targets:
+        - MSFMenuBarCoreTests

--- a/web/src/app/settings/SettingsClient.tsx
+++ b/web/src/app/settings/SettingsClient.tsx
@@ -160,6 +160,9 @@ interface NetworkInterfaceInfo {
   ip?: string;
   primary_ip?: string;
   addresses?: string[];
+  is_usable?: boolean;
+  is_default?: boolean;
+  recommended?: boolean;
 }
 
 const tabs: Array<{ id: TabId; label: string; Icon: LucideIcon }> = [
@@ -476,7 +479,7 @@ function serializeSubscriptions(rows: SubscriptionRow[]) {
     .join("\n");
 }
 
-function setupToInitConfig(raw: any, forceTun = false): InitConfigState {
+function setupToInitConfig(raw: any, forceTun = false, forceAutoDNS = false): InitConfigState {
   const data = raw && typeof raw === "object" ? raw : {};
   const subscriptions = parseSubscriptionValue(data.subscription_urls || data.subscriptionURLs);
   const mihomoProxies = String(data.mihomo_proxies || data.mihomoProxies || "");
@@ -488,7 +491,7 @@ function setupToInitConfig(raw: any, forceTun = false): InitConfigState {
     proxyCore: String(data.proxy_core || data.proxyCore || "mihomo").toLowerCase() === "none" ? "无" : "Mihomo",
     mihomoType: String(data.mihomo_core_type || data.mihomoCoreType || "meta").toLowerCase() === "alpha" ? "Alpha" : "Meta",
     proxyMode: forceTun || String(data.linux_proxy_mode || "nft").toLowerCase() === "tun" ? "tun" : "nft",
-    autoDns: data.auto_set_dns ?? data.autoSetDNS ?? true,
+    autoDns: forceAutoDNS || (data.auto_set_dns ?? data.autoSetDNS ?? true),
     dnsEnable: String(data.dns_on || data.dnsOn || "127.0.0.1"),
     dnsDisable: String(data.dns_off || data.dnsOff || "223.5.5.5"),
     ipv6: Boolean(data.enable_ipv6 ?? data.enableIPv6),
@@ -798,11 +801,13 @@ function ProfileTab({ showToast }: { showToast: (message: string) => void }) {
 
 function InitConfigSummary({
   config,
+  macOSRuntime,
   visibleSecrets,
   onReveal,
   onEdit,
 }: {
   config: InitConfigState;
+  macOSRuntime: boolean;
   visibleSecrets: Record<string, boolean>;
   onReveal: (id: string) => void;
   onEdit: () => void;
@@ -816,9 +821,9 @@ function InitConfigSummary({
         <PlainInfo label="选定网卡" value={config.iface.replace(" (192.168.10.3)", "")} />
         <PlainInfo label="代理核心类型" value={`${config.proxyCore} (${config.mihomoType.toLowerCase()})`} />
         <PlainInfo label="透明代理模式" value={config.proxyMode === "tun" ? "TUN" : "nftables"} />
-        <PlainInfo label="自动设置 DNS" value={config.autoDns ? "已启用" : "已禁用"} />
-        <PlainInfo label="DNS 启用地址" value={config.dnsEnable} />
-        <PlainInfo label="DNS 禁用地址" value={config.dnsDisable} />
+        <PlainInfo label="自动设置 DNS" value={macOSRuntime ? "由 TUN 强制启用" : config.autoDns ? "已启用" : "已禁用"} />
+        <PlainInfo label="DNS 启用地址" value={macOSRuntime ? "127.0.0.1" : config.dnsEnable} />
+        <PlainInfo label="DNS 停用恢复" value={macOSRuntime ? "按启动前系统快照恢复" : config.dnsDisable} />
         <PlainInfo label="启用 IPv6" value={config.ipv6 ? "已启用" : "DNS自动设置"} />
         <PlainInfo label="代理服务器" value={config.githubProxyEnabled ? "已启用" : "已禁用"} />
         <PlainInfo label="GitHub 加速源" value={config.githubAcceleratorEnabled ? "已启用" : "已禁用"} />
@@ -855,6 +860,7 @@ function InitConfigEditor({
   onSave,
   networkInterfaces,
   dockerRuntime,
+  macOSRuntime,
 }: {
   draft: InitConfigState;
   setDraft: (updater: (current: InitConfigState) => InitConfigState) => void;
@@ -862,7 +868,9 @@ function InitConfigEditor({
   onSave: () => void;
   networkInterfaces: NetworkInterfaceInfo[];
   dockerRuntime: boolean;
+  macOSRuntime: boolean;
 }) {
+  const tunOnlyRuntime = dockerRuntime || macOSRuntime;
   const updateSub = (id: string, patch: Partial<SubscriptionRow>) => {
     setDraft((current) => ({
       ...current,
@@ -905,8 +913,8 @@ function InitConfigEditor({
         >
           <option>请选择网卡接口</option>
           {networkInterfaces.map((iface) => (
-            <option key={iface.name} value={iface.name}>
-              {iface.name}{iface.primary_ip || iface.ip ? ` (${iface.primary_ip || iface.ip})` : ""}
+            <option key={iface.name} value={iface.name} disabled={macOSRuntime && iface.is_usable === false}>
+              {iface.name}{iface.primary_ip || iface.ip ? ` (${iface.primary_ip || iface.ip})` : "（无可用 IP）"}{iface.recommended ? " · 默认出口" : ""}
             </option>
           ))}
         </select>
@@ -915,15 +923,19 @@ function InitConfigEditor({
       <SectionBox>
         <h3 className="text-lg font-semibold text-foreground">透明代理模式</h3>
         <p className="mt-1 text-sm text-muted-foreground">
-          {dockerRuntime ? "Docker 仅支持 TUN，需提供 /dev/net/tun、CAP_NET_ADMIN 与 CAP_NET_RAW。" : "generated 配置会随模式切换原子重建；自定义配置冲突时后端会拒绝切换。"}
+          {macOSRuntime
+            ? "macOS 仅支持 TUN；由 LaunchDaemon 管理 utun、本机 DNS 与 LAN IPv4 转发。"
+            : dockerRuntime
+              ? "Docker 仅支持 TUN，需提供 /dev/net/tun、CAP_NET_ADMIN 与 CAP_NET_RAW。"
+              : "generated 配置会随模式切换原子重建；自定义配置冲突时后端会拒绝切换。"}
         </p>
         <select
-          value={dockerRuntime ? "tun" : draft.proxyMode}
-          disabled={dockerRuntime}
+          value={tunOnlyRuntime ? "tun" : draft.proxyMode}
+          disabled={tunOnlyRuntime}
           onChange={(event) => setDraft((current) => ({ ...current, proxyMode: event.target.value as InitConfigState["proxyMode"] }))}
           className={`${inputClass} mt-4 h-12 text-base`}
         >
-          {!dockerRuntime && <option value="nft">nftables（TProxy + Redirect）</option>}
+          {!tunOnlyRuntime && <option value="nft">nftables（TProxy + Redirect）</option>}
           <option value="tun">TUN</option>
         </select>
       </SectionBox>
@@ -964,30 +976,38 @@ function InitConfigEditor({
         <label className="flex items-center gap-3 text-lg font-semibold text-foreground">
           <input
             type="checkbox"
-            checked={draft.autoDns}
+            checked={macOSRuntime ? true : draft.autoDns}
+            disabled={macOSRuntime}
             onChange={(event) => setDraft((current) => ({ ...current, autoDns: event.target.checked }))}
-            className="h-5 w-5 accent-primary"
+            className="h-5 w-5 accent-primary disabled:cursor-not-allowed disabled:opacity-70"
           />
-          自动设置 DNS
+          {macOSRuntime ? "macOS DNS 自动接管" : "自动设置 DNS"}
         </label>
+        {macOSRuntime ? (
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            TUN 启动时固定使用本机 MosDNS（127.0.0.1）；完全停止时自动恢复启动前捕获的各网络服务 DNS 快照。
+          </p>
+        ) : null}
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <Field label="DNS 启用地址">
             <input
-              value={draft.dnsEnable}
+              value={macOSRuntime ? "127.0.0.1" : draft.dnsEnable}
+              disabled={macOSRuntime}
               onChange={(event) => setDraft((current) => ({ ...current, dnsEnable: event.target.value }))}
               placeholder="例如: 127.0.0.1"
               className={`${inputClass} h-12 text-base`}
             />
-            <p className="mt-1 text-xs text-muted-foreground">例如: 127.0.0.1</p>
+            <p className="mt-1 text-xs text-muted-foreground">{macOSRuntime ? "macOS TUN 固定值" : "例如: 127.0.0.1"}</p>
           </Field>
-          <Field label="DNS 禁用地址">
+          <Field label={macOSRuntime ? "DNS 停用恢复" : "DNS 禁用地址"}>
             <input
-              value={draft.dnsDisable}
+              value={macOSRuntime ? "按启动前系统快照恢复" : draft.dnsDisable}
+              disabled={macOSRuntime}
               onChange={(event) => setDraft((current) => ({ ...current, dnsDisable: event.target.value }))}
               placeholder="例如: 8.8.8.8"
               className={`${inputClass} h-12 text-base`}
             />
-            <p className="mt-1 text-xs text-muted-foreground">例如: 127.0.0.1</p>
+            <p className="mt-1 text-xs text-muted-foreground">{macOSRuntime ? "不会写死公共 DNS" : "例如: 8.8.8.8"}</p>
           </Field>
         </div>
       </SectionBox>
@@ -1239,6 +1259,7 @@ function SystemTab({ showToast }: { showToast: (message: string) => void }) {
   const [networkInterfaces, setNetworkInterfaces] = useState<NetworkInterfaceInfo[]>([]);
   const [saving, setSaving] = useState(false);
   const [dockerRuntime, setDockerRuntime] = useState(false);
+  const [macOSRuntime, setMacOSRuntime] = useState(false);
 
   useEffect(() => {
     Promise.allSettled([
@@ -1248,7 +1269,9 @@ function SystemTab({ showToast }: { showToast: (message: string) => void }) {
       api("/api/v1/setup/privilege"),
     ]).then(([settingsResult, configResult, interfacesResult, privilegeResult]) => {
       const docker = privilegeResult.status === "fulfilled" && Boolean((privilegeResult.value as any)?.runtime?.docker);
+      const macos = privilegeResult.status === "fulfilled" && Boolean((privilegeResult.value as any)?.runtime?.macos);
       setDockerRuntime(docker);
+      setMacOSRuntime(macos);
       if (settingsResult.status === "fulfilled") {
         const data = apiData<Record<string, string>>(settingsResult.value, {});
         const hours = Number(data.token_retention_hours || data.jwt_expire_hours || data.jwt_expiry_hours || data.token_ttl_hours || 24);
@@ -1258,7 +1281,7 @@ function SystemTab({ showToast }: { showToast: (message: string) => void }) {
         setNetworkInterfaces(apiList<NetworkInterfaceInfo>(interfacesResult.value, ["data", "interfaces", "items"]));
       }
       if (configResult.status === "fulfilled") {
-        const config = setupToInitConfig(apiData<any>(configResult.value, configResult.value), docker);
+        const config = setupToInitConfig(apiData<any>(configResult.value, configResult.value), docker || macos, macos);
         setInitConfig(config);
         setDraftConfig(config);
       } else {
@@ -1285,7 +1308,9 @@ function SystemTab({ showToast }: { showToast: (message: string) => void }) {
   const saveInitConfig = async () => {
     setSaving(true);
     try {
-      const nextConfig = dockerRuntime ? { ...draftConfig, proxyMode: "tun" as const } : draftConfig;
+      const nextConfig = dockerRuntime || macOSRuntime
+        ? { ...draftConfig, proxyMode: "tun" as const, ...(macOSRuntime ? { autoDns: true, dnsEnable: "127.0.0.1" } : {}) }
+        : draftConfig;
       await api("/api/v1/setup/config", {
         method: "PUT",
         body: JSON.stringify(initConfigToSetupPayload(nextConfig)),
@@ -1333,6 +1358,7 @@ function SystemTab({ showToast }: { showToast: (message: string) => void }) {
             setDraft={setDraftConfig}
             networkInterfaces={networkInterfaces}
             dockerRuntime={dockerRuntime}
+            macOSRuntime={macOSRuntime}
             onCancel={() => {
               setDraftConfig(initConfig);
               setEditingInit(false);
@@ -1342,6 +1368,7 @@ function SystemTab({ showToast }: { showToast: (message: string) => void }) {
         ) : (
           <InitConfigSummary
             config={initConfig}
+            macOSRuntime={macOSRuntime}
             visibleSecrets={visibleSecrets}
             onReveal={(id) => setVisibleSecrets((current) => ({ ...current, [id]: !current[id] }))}
             onEdit={() => {

--- a/web/src/pages/SetupPage.tsx
+++ b/web/src/pages/SetupPage.tsx
@@ -40,6 +40,9 @@ interface NetworkInterface {
   primary_ip?: string;
   is_loopback?: boolean;
   is_up?: boolean;
+  is_usable?: boolean;
+  is_default?: boolean;
+  recommended?: boolean;
   speed?: string | number;
 }
 
@@ -63,6 +66,7 @@ interface PrivilegeInfo {
   runtime?: {
     docker?: boolean;
     docker_network_mode?: string;
+    macos?: boolean;
   };
 }
 
@@ -947,15 +951,37 @@ export function SetupPage() {
     ]).then(([privilegeResult, systemResult, networkResult]) => {
       if (privilegeResult.status === "fulfilled") {
         setPrivilege(privilegeResult.value);
-        if (privilegeResult.value?.runtime?.docker) {
-          setForm((current) => ({ ...current, linux_proxy_mode: "tun", enableIPv6: false }));
+        const dockerRuntime = Boolean(privilegeResult.value?.runtime?.docker);
+        const macOSRuntime = Boolean(privilegeResult.value?.runtime?.macos);
+        if (dockerRuntime || macOSRuntime) {
+          setForm((current) => ({
+            ...current,
+            linux_proxy_mode: "tun",
+            enableIPv6: false,
+            ...(macOSRuntime ? { auto_set_dns: true, dns_on: "127.0.0.1" } : {}),
+          }));
         }
       }
-      if (systemResult.status === "fulfilled") setSystem(systemResult.value);
+      if (systemResult.status === "fulfilled") {
+        setSystem(systemResult.value);
+        if (systemResult.value?.system?.os === "darwin") {
+          setForm((current) => ({
+            ...current,
+            linux_proxy_mode: "tun",
+            auto_set_dns: true,
+            dns_on: "127.0.0.1",
+            enableIPv6: false,
+          }));
+        }
+      }
       if (networkResult.status === "fulfilled") {
         const rows = networkRows(networkResult.value);
         setIfaces(rows);
-        const first = rows.find((item) => item.is_up && !item.is_loopback) || rows[0];
+        const first =
+          rows.find((item) => item.recommended || (item.is_default && item.is_usable !== false))
+          || rows.find((item) => item.is_up && !item.is_loopback && Boolean(item.primary_ip || item.ip))
+          || rows.find((item) => item.is_usable)
+          || rows[0];
         if (first?.name) setForm((current) => ({ ...current, selected_interface: first.name }));
       }
       const firstError = [privilegeResult, systemResult, networkResult].find((result) => result.status === "rejected");
@@ -987,6 +1013,8 @@ export function SetupPage() {
   const occupiedPorts = useMemo(() => occupiedReservedPorts(preflight), [preflight]);
   const hasPortWarnings = occupiedPorts.length > 0;
   const isDockerRuntime = Boolean(privilege?.runtime?.docker);
+  const isMacOSRuntime = Boolean(privilege?.runtime?.macos) || system?.system?.os === "darwin";
+  const isTunOnlyRuntime = isDockerRuntime || isMacOSRuntime;
 
   const fetchPreflight = useCallback(async () => {
     setPreflightBusy(true);
@@ -1010,7 +1038,8 @@ export function SetupPage() {
   }, [downloadStatus, fetchPreflight, step]);
 
   const update = (key: keyof SetupForm, value: string | boolean) => {
-    if (key === "linux_proxy_mode" && isDockerRuntime && value !== "tun") return;
+    if (key === "linux_proxy_mode" && isTunOnlyRuntime && value !== "tun") return;
+    if (key === "auto_set_dns" && isMacOSRuntime && value !== true) return;
     if (key === "timezone" || key === "linux_proxy_mode") {
       setPreflight(null);
       setPortRiskAccepted(false);
@@ -1415,8 +1444,8 @@ export function SetupPage() {
                           >
                             {ifaces.length === 0 && <option value="">请选择网络接口</option>}
                             {ifaces.map((iface) => (
-                              <option key={iface.name} value={iface.name}>
-                                {iface.name} - {iface.primary_ip || iface.ip || "-"} {iface.speed ? `(${iface.speed})` : ""}
+                              <option key={iface.name} value={iface.name} disabled={isMacOSRuntime && iface.is_usable === false}>
+                                {iface.name} - {iface.primary_ip || iface.ip || "无可用 IP"} {iface.recommended ? "（默认出口）" : iface.speed ? `(${iface.speed})` : ""}
                               </option>
                             ))}
                           </select>
@@ -1437,15 +1466,22 @@ export function SetupPage() {
                     <div className="rounded-lg border border-border bg-background p-3">
                       <div className="flex items-center justify-between gap-4">
                         <div>
-                          <div className="text-xs font-semibold">自动修改本机 DNS</div>
+                          <div className="text-xs font-semibold">{isMacOSRuntime ? "macOS DNS 自动接管" : "自动修改本机 DNS"}</div>
                           <div className="mt-1 text-[11px] leading-5 text-muted-foreground">
-                            开启后自动将系统 DNS 切换为 mosdns（127.0.0.1），关闭则仅生成配置不改动系统 DNS
+                            {isMacOSRuntime
+                              ? "TUN 启动时固定切换到本机 MosDNS（127.0.0.1）；完全停止时按启动前快照恢复各网络服务的原始 DNS。"
+                              : "开启后自动将系统 DNS 切换为 mosdns（127.0.0.1），关闭则仅生成配置不改动系统 DNS"}
                           </div>
                         </div>
                         <button
                           type="button"
                           onClick={() => update("auto_set_dns", !form.auto_set_dns)}
-                          className={cn("relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0", form.auto_set_dns ? "bg-primary" : "bg-muted")}
+                          disabled={isMacOSRuntime}
+                          className={cn(
+                            "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0",
+                            form.auto_set_dns ? "bg-primary" : "bg-muted",
+                            isMacOSRuntime && "cursor-not-allowed opacity-80"
+                          )}
                           aria-label="自动修改本机 DNS"
                           aria-pressed={form.auto_set_dns}
                         >
@@ -1454,11 +1490,21 @@ export function SetupPage() {
                       </div>
                     </div>
                     <div className="mt-3 grid gap-3 sm:grid-cols-2">
-                      <Field label="服务启动后本机 DNS" hint="服务启动后系统将使用的 DNS 地址，默认 127.0.0.1">
-                        <input className={cn(inputClass, "h-8 text-xs")} value={form.dns_on} onChange={(event) => update("dns_on", event.target.value)} />
+                      <Field label="服务启动后本机 DNS" hint={isMacOSRuntime ? "macOS TUN 固定使用本机 MosDNS" : "服务启动后系统将使用的 DNS 地址，默认 127.0.0.1"}>
+                        <input
+                          className={cn(inputClass, "h-8 text-xs")}
+                          value={isMacOSRuntime ? "127.0.0.1" : form.dns_on}
+                          disabled={isMacOSRuntime}
+                          onChange={(event) => update("dns_on", event.target.value)}
+                        />
                       </Field>
-                      <Field label="服务停止后本机 DNS" hint="服务停止后恢复的 DNS 地址，默认 223.5.5.5">
-                        <input className={cn(inputClass, "h-8 text-xs")} value={form.dns_off} onChange={(event) => update("dns_off", event.target.value)} />
+                      <Field label="服务停止后本机 DNS" hint={isMacOSRuntime ? "完整停止时恢复启动前捕获的系统 DNS 快照" : "服务停止后恢复的 DNS 地址，默认 223.5.5.5"}>
+                        <input
+                          className={cn(inputClass, "h-8 text-xs")}
+                          value={isMacOSRuntime ? "按启动前系统快照恢复" : form.dns_off}
+                          disabled={isMacOSRuntime}
+                          onChange={(event) => update("dns_off", event.target.value)}
+                        />
                       </Field>
                     </div>
                   </div>
@@ -1583,15 +1629,17 @@ export function SetupPage() {
                       <SlidersHorizontal className="h-4 w-4" />
                     </span>
                     <div>
-                      <div className="text-sm font-semibold">Linux 透明代理</div>
-                      <div className="text-xs text-muted-foreground">Linux 透明代理配置</div>
+                      <div className="text-sm font-semibold">{isMacOSRuntime ? "macOS TUN 网络" : "Linux 透明代理"}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {isMacOSRuntime ? "由系统 LaunchDaemon 管理 DNS、utun 与 LAN 转发" : "Linux 透明代理配置"}
+                      </div>
                     </div>
                   </div>
                   <div className="space-y-3">
                     <div>
-                      <div className="mb-2 text-sm font-medium">Linux 透明代理模式</div>
+                      <div className="mb-2 text-sm font-medium">{isMacOSRuntime ? "macOS 接管模式" : "Linux 透明代理模式"}</div>
                       <div className="grid gap-3 sm:grid-cols-2">
-                        {!isDockerRuntime && (
+                        {!isTunOnlyRuntime && (
                           <ChoiceCard
                             title="nftables 转发（TProxy + Redirect）"
                             description="Linux 下 Mihomo 支持 nftables 转发，默认使用 nftables 转发。"
@@ -1600,9 +1648,17 @@ export function SetupPage() {
                           />
                         )}
                         <ChoiceCard
-                          title={isDockerRuntime ? "TUN 模式（Docker 唯一支持模式）" : "TUN 模式"}
+                          title={
+                            isMacOSRuntime
+                              ? "TUN 模式（macOS 唯一支持模式）"
+                              : isDockerRuntime
+                                ? "TUN 模式（Docker 唯一支持模式）"
+                                : "TUN 模式"
+                          }
                           description={
-                            isDockerRuntime
+                            isMacOSRuntime
+                              ? "MosDNS 接管本机与局域网 DNS，Mihomo utun 接管 Fake-IP 路由；停止时保留 TUN 并切换为直连。"
+                              : isDockerRuntime
                               ? "需要 /dev/net/tun 与 NET_ADMIN；由 MosDNS 负责 DNS 分流，Mihomo TUN 接管 Fake-IP 路由。"
                               : "需要 /dev/net/tun、NET_ADMIN 和正确 DNS 链路；Mihomo TUN 接管 Fake-IP 路由，不写 nftables 策略。"
                           }


### PR DESCRIPTION
## Summary

- add the macOS 15–26 Universal 2 menu bar app with a root LaunchDaemon and TUN-only runtime
- add Darwin component downloads, system/network monitoring, provider compatibility, and WebUI platform handling
- add v0.4.0 version provenance, Developer ID/notarization packaging, and a unified tag release workflow
- update README, installation docs, release handbook, platform version references, and CHANGELOG

## Validation

- go test ./...
- npm --prefix web run check
- 13 Swift tests
- unsigned Debug/Release Universal 2 builds and bundle verification
- Linux amd64/arm64 package builds
- Unraid 0.4.0 package build
- fnOS x86/ARM 0.4.0 FPK builds
- compliance audit
- actionlint for release workflows

## Release note

The macOS app is marked Beta and remains TUN-only. Public DMG/ZIP publication requires a Developer ID Application certificate and Apple notarization credentials.