### PR TITLE
build: publish macOS beta with legacy installer

### DIFF
--- a/.github/workflows/macos-menu-bar.yml
+++ b/.github/workflows/macos-menu-bar.yml
@@ -58,10 +58,10 @@ jobs:
         run: make macos-app-build-debug macos-app-build-release XCODE_DEVELOPER_DIR="$(xcode-select -p)"
 
       - name: Verify Debug app bundle
-        run: make macos-app-verify MACOS_CONFIGURATION=Debug XCODE_DEVELOPER_DIR="$(xcode-select -p)"
+        run: MSF_REQUIRE_LEGACY_ONLY=1 make macos-app-verify MACOS_CONFIGURATION=Debug XCODE_DEVELOPER_DIR="$(xcode-select -p)"
 
       - name: Verify Release app bundle
-        run: make macos-app-verify MACOS_CONFIGURATION=Release XCODE_DEVELOPER_DIR="$(xcode-select -p)"
+        run: MSF_REQUIRE_LEGACY_ONLY=1 make macos-app-verify MACOS_CONFIGURATION=Release XCODE_DEVELOPER_DIR="$(xcode-select -p)"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,13 +155,6 @@ jobs:
   macos-assets:
     needs: source
     runs-on: macos-15
-    env:
-      MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
-      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
-      APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
     steps:
       - name: Checkout exact tag
         uses: actions/checkout@v4
@@ -191,62 +184,27 @@ jobs:
           npm --prefix web run check
           make macos-app-test XCODE_DEVELOPER_DIR="$(xcode-select -p)"
 
-      - name: Import Developer ID and configure notarization
-        id: signing
-        shell: bash
+      - name: Build and package unsigned macOS beta assets
         run: |
-          set -euo pipefail
-          for name in MACOS_CERTIFICATE_P12 MACOS_CERTIFICATE_PASSWORD APPLE_TEAM_ID APPLE_API_KEY_ID APPLE_API_ISSUER_ID APPLE_API_PRIVATE_KEY; do
-            test -n "${!name}" || { echo "Missing required secret: $name" >&2; exit 1; }
-          done
-          certificate_path="$RUNNER_TEMP/developer-id.p12"
-          api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          keychain_path="$RUNNER_TEMP/msf-signing.keychain-db"
-          keychain_password="$(uuidgen)"
-          notary_profile="msf-release"
-          printf '%s' "$MACOS_CERTIFICATE_P12" | /usr/bin/base64 -D > "$certificate_path"
-          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$api_key_path"
-          security create-keychain -p "$keychain_password" "$keychain_path"
-          security set-keychain-settings -lut 21600 "$keychain_path"
-          security unlock-keychain -p "$keychain_password" "$keychain_path"
-          security import "$certificate_path" -k "$keychain_path" -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain_path"
-          security list-keychains -d user -s "$keychain_path"
-          security default-keychain -d user -s "$keychain_path"
-          identity="$(security find-identity -v -p codesigning "$keychain_path" | awk '/Developer ID Application/ {print $2; exit}')"
-          test -n "$identity" || { echo "Developer ID Application identity not found" >&2; exit 1; }
-          xcrun notarytool store-credentials "$notary_profile" \
-            --key "$api_key_path" \
-            --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER_ID"
-          {
-            echo "identity=$identity"
-            echo "notary_profile=$notary_profile"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build, sign, notarize, and package macOS assets
-        run: |
+          echo "::warning::The macOS Beta is intentionally unsigned and uses the legacy administrator installer."
           make macos-release-assets \
             VERSION=${{ needs.source.outputs.version }} \
             RELEASE_TAG=${{ needs.source.outputs.tag }} \
             BUILD_TIME=${{ needs.source.outputs.build_time }} \
             MACOS_BUILD_NUMBER=${GITHUB_RUN_NUMBER} \
-            MACOS_DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            MACOS_SIGNING_IDENTITY="${{ steps.signing.outputs.identity }}" \
-            MACOS_NOTARY_PROFILE="${{ steps.signing.outputs.notary_profile }}" \
             XCODE_DEVELOPER_DIR="$(xcode-select -p)"
 
-      - name: Upload signed and notarized macOS assets
+      - name: Upload unsigned macOS beta assets
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-assets
           if-no-files-found: error
           retention-days: 7
           path: |
-            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal.dmg
-            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal.dmg.sha256
-            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal.zip
-            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal.zip.sha256
+            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal-unsigned.dmg
+            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal-unsigned.dmg.sha256
+            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal-unsigned.zip
+            dist/macos/MSF-${{ needs.source.outputs.version }}-macos-universal-unsigned.zip.sha256
 
   publish:
     needs:
@@ -303,10 +261,10 @@ jobs:
             "dist/msf_${version}_x86.fpk.sha256"
             "dist/msf_${version}_arm.fpk"
             "dist/msf_${version}_arm.fpk.sha256"
-            "dist/macos/MSF-${version}-macos-universal.dmg"
-            "dist/macos/MSF-${version}-macos-universal.dmg.sha256"
-            "dist/macos/MSF-${version}-macos-universal.zip"
-            "dist/macos/MSF-${version}-macos-universal.zip.sha256"
+            "dist/macos/MSF-${version}-macos-universal-unsigned.dmg"
+            "dist/macos/MSF-${version}-macos-universal-unsigned.dmg.sha256"
+            "dist/macos/MSF-${version}-macos-universal-unsigned.zip"
+            "dist/macos/MSF-${version}-macos-universal-unsigned.zip.sha256"
           )
           for asset in "${assets[@]}"; do
             test -f "$asset" || { echo "Missing release asset: $asset" >&2; exit 1; }
@@ -323,8 +281,8 @@ jobs:
           (
             cd dist/macos
             sha256sum -c \
-              "MSF-${version}-macos-universal.dmg.sha256" \
-              "MSF-${version}-macos-universal.zip.sha256"
+              "MSF-${version}-macos-universal-unsigned.dmg.sha256" \
+              "MSF-${version}-macos-universal-unsigned.zip.sha256"
           )
           gh release create "${{ needs.source.outputs.tag }}" \
             --verify-tag \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@
 #### 说明
 
 - v0.4.0 首次加入 macOS 15–26 菜单栏 App 支持；macOS App 第一版为 Beta，仅提供 TUN 模式，不提供系统代理模式，有问题请及时反馈。
-- 本版本从 `main` 的同一个干净 tag 构建 Linux、Unraid、fnOS、macOS 与 Docker；GitHub Release 增加已签名、公证的 Universal 2 DMG/ZIP 及 SHA-256。
+- 本版本从 `main` 的同一个干净 tag 构建 Linux、Unraid、fnOS、macOS 与 Docker；GitHub Release 增加名称带 `-unsigned` 的 Universal 2 DMG/ZIP 及 SHA-256。首个 macOS Beta 未使用 Apple Developer ID 或公证，首次打开需要用户手动允许。
 
 #### 新增
 
 - 新增原生 SwiftUI Universal 2 菜单栏 App，覆盖 Apple Silicon 与 Intel，支持启动、LAN 直连保活停止、重启、完全停止、打开网页管理页和实时上下行速度。
-- 新增 root LaunchDaemon 和统一 Network Runtime API；macOS 启用时保存并恢复网络服务 DNS 与原始 IPv4 转发状态，允许系统动态分配 `utunN`，并验证 DNS、Fake-IP 路由和 IPv4 转发状态。
+- 新增 root LaunchDaemon 和统一 Network Runtime API；未签名 Beta 通过管理员授权的 legacy Installer 安装到 `/Library`，默认不调用 `SMAppService`。macOS 启用时保存并恢复网络服务 DNS 与原始 IPv4 转发状态，允许系统动态分配 `utunN`，并验证 DNS、Fake-IP 路由和 IPv4 转发状态。
 - 组件下载增加 Mihomo 官方 Darwin 资产、兼容扩展插件的 mssb MosDNS Darwin 资产、GitHub SHA-256 digest 和 Mach-O 架构校验；Web 初始化与系统设置在 macOS 下强制 TUN 并隐藏 nftables。
 
 #### 修复
@@ -26,12 +26,12 @@
 #### Notes
 
 - v0.4.0 introduces the macOS 15–26 menu bar app. The first macOS release is Beta, supports TUN only, does not provide system-proxy mode, and users are encouraged to report problems promptly.
-- Linux, Unraid, fnOS, macOS, and Docker are built from the same clean tag on `main`. GitHub Release now includes signed and notarized Universal 2 DMG/ZIP assets with SHA-256 files.
+- Linux, Unraid, fnOS, macOS, and Docker are built from the same clean tag on `main`. GitHub Release includes Universal 2 DMG/ZIP assets named with `-unsigned` plus SHA-256 files. The first macOS Beta is not Developer ID signed or notarized, so users must explicitly allow the first launch.
 
 #### Added
 
 - Added a native SwiftUI Universal 2 menu bar app for Apple Silicon and Intel with start, LAN-safe direct stop, restart, full stop, WebUI access, and live upload/download speed.
-- Added a root LaunchDaemon and unified Network Runtime API. macOS activation snapshots and restores network-service DNS and the original IPv4 forwarding value, lets the system allocate `utunN`, and validates DNS, Fake-IP routing, and forwarding readiness.
+- Added a root LaunchDaemon and unified Network Runtime API. The unsigned Beta installs it into `/Library` through an administrator-authorized legacy installer and does not call `SMAppService` by default. macOS activation snapshots and restores network-service DNS and the original IPv4 forwarding value, lets the system allocate `utunN`, and validates DNS, Fake-IP routing, and forwarding readiness.
 - Component downloads now use official Mihomo Darwin assets and mssb MosDNS Darwin builds with the required extension plugins, GitHub SHA-256 digests, and Mach-O architecture validation. Web setup/settings force TUN and hide nftables on macOS.
 
 #### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build frontend import-web package release-package release-assets checksums verify-release-source verify-release-assets unraid fnos test audit-compliance macos-app-project macos-app-test macos-app-build macos-app-build-debug macos-app-build-release macos-app-build-signed macos-app-verify macos-release-assets macos-app-open clean
+.PHONY: dev build frontend import-web package release-package release-assets checksums verify-release-source verify-release-assets unraid fnos test audit-compliance macos-app-project macos-app-test macos-app-build macos-app-build-debug macos-app-build-release macos-app-build-release-assets macos-app-build-signed macos-app-verify macos-release-assets macos-release-assets-signed macos-app-open clean
 
 APP_NAME := msf
 DIST := dist
@@ -153,6 +153,29 @@ macos-app-build-release: frontend macos-app-project
 		CODE_SIGNING_ALLOWED=NO \
 		build
 
+macos-app-build-release-assets: frontend macos-app-project
+	@test "$(VERSION)" != "0.1.0-dev" || { echo "VERSION must be set for a macOS release build" >&2; exit 1; }
+	cd $(MACOS_APP_DIR) && DEVELOPER_DIR=$(XCODE_DEVELOPER_DIR) xcodebuild \
+		-project MSFMenuBar.xcodeproj \
+		-scheme MSFMenuBar \
+		-configuration Release \
+		-derivedDataPath DerivedData \
+		ONLY_ACTIVE_ARCH=NO \
+		ARCHS="arm64 x86_64" \
+		MARKETING_VERSION="$(VERSION)" \
+		CURRENT_PROJECT_VERSION="$(MACOS_BUILD_NUMBER)" \
+		MSF_VERSION="$(VERSION)" \
+		MSF_BUILD_COMMIT="$(GIT_COMMIT)" \
+		MSF_BUILD_TAG="$(BUILD_TAG)" \
+		MSF_BUILD_TAG_COMMIT="$(TAG_COMMIT)" \
+		MSF_BUILD_SOURCE_COMMIT="$(SOURCE_COMMIT)" \
+		MSF_BUILD_DIRTY="$(BUILD_DIRTY)" \
+		MSF_BUILD_TIME="$(BUILD_TIME)" \
+		ENABLE_HARDENED_RUNTIME=NO \
+		CODE_SIGNING_ALLOWED=NO \
+		CODE_SIGNING_REQUIRED=NO \
+		build
+
 macos-app-build-signed: frontend macos-app-project
 	@test "$(VERSION)" != "0.1.0-dev" || { echo "VERSION must be set for a signed macOS build" >&2; exit 1; }
 	@test -n "$(MACOS_DEVELOPMENT_TEAM)" || { echo "MACOS_DEVELOPMENT_TEAM is required" >&2; exit 1; }
@@ -173,6 +196,7 @@ macos-app-build-signed: frontend macos-app-project
 		MSF_BUILD_SOURCE_COMMIT="$(SOURCE_COMMIT)" \
 		MSF_BUILD_DIRTY="$(BUILD_DIRTY)" \
 		MSF_BUILD_TIME="$(BUILD_TIME)" \
+		SWIFT_ACTIVE_COMPILATION_CONDITIONS='$$(inherited) MSF_SIGNED_RELEASE' \
 		CODE_SIGNING_ALLOWED=YES \
 		CODE_SIGNING_REQUIRED=YES \
 		CODE_SIGN_STYLE=Manual \
@@ -185,12 +209,16 @@ macos-app-build-signed: frontend macos-app-project
 macos-app-verify:
 	cd $(MACOS_APP_DIR) && DEVELOPER_DIR=$(XCODE_DEVELOPER_DIR) Scripts/verify-app.sh $(MACOS_CONFIGURATION)
 
-macos-release-assets: verify-release-source macos-app-build-signed
+macos-release-assets: verify-release-source macos-app-build-release-assets
+	cd $(MACOS_APP_DIR) && \
+		Scripts/package-release.sh "$(VERSION)" "$(RELEASE_TAG)" "$(GIT_COMMIT)" "$(abspath $(MACOS_RELEASE_DIR))"
+
+macos-release-assets-signed: verify-release-source macos-app-build-signed
 	@test -n "$(MACOS_NOTARY_PROFILE)" || { echo "MACOS_NOTARY_PROFILE is required" >&2; exit 1; }
 	cd $(MACOS_APP_DIR) && \
 		MACOS_SIGNING_IDENTITY="$(MACOS_SIGNING_IDENTITY)" \
 		MACOS_NOTARY_PROFILE="$(MACOS_NOTARY_PROFILE)" \
-		Scripts/package-release.sh "$(VERSION)" "$(RELEASE_TAG)" "$(GIT_COMMIT)" "$(abspath $(MACOS_RELEASE_DIR))"
+		Scripts/package-release-signed.sh "$(VERSION)" "$(RELEASE_TAG)" "$(GIT_COMMIT)" "$(abspath $(MACOS_RELEASE_DIR))"
 
 macos-app-open: macos-app-build-debug
 	open $(MACOS_APP_DIR)/DerivedData/Build/Products/Debug/MSF.app

--- a/README.en.md
+++ b/README.en.md
@@ -22,7 +22,7 @@ Current release: `v0.4.0`
 - Mihomo custom configs, CodeMirror YAML editing, component update checks, automatic downloads, update notices, and configurable upgrade behavior.
 - Local upload installation for MosDNS, Mihomo, and Zashboard when online downloads are difficult.
 - Linux tarball/systemd, fnOS FPK, and Unraid PLG support both nftables and TUN. Docker `host-tun` / `macvlan-tun` is supported and TUN-only.
-- macOS 15–26 has a Beta native Universal 2 menu bar app, a root LaunchDaemon, and a TUN-only runtime. It does not use macOS system-proxy mode.
+- macOS 15–26 has an unsigned Beta native Universal 2 menu bar app, a root LaunchDaemon, and a TUN-only runtime. It does not use macOS system-proxy mode, and users must explicitly allow the first launch.
 - Docker deployments must mount a host data directory to container `/opt/msf`; the default examples use `./msf-data:/opt/msf`.
 
 ## Architecture Diagram
@@ -39,7 +39,7 @@ Current release: `v0.4.0`
 | fnOS FPK | Supported | [fnOS FPK install](docs/install/fnos-fpk.md) | fnOS / Feiniu App Center or FPK package manager |
 | Unraid PLG | Stable | [Unraid PLG install](docs/install/unraid-plg.md) | Unraid plugin manager |
 | Docker TUN host/macvlan | Supported (TUN-only) | [Docker TUN deployment](docs/docker.en.md) | Docker / Compose / container manager |
-| macOS 15–26 menu bar app | Beta (TUN-only) | [macOS installation and usage](docs/install/macos.md) | In-app daemon installation, repair, and removal |
+| macOS 15–26 menu bar app | Unsigned Beta (TUN-only) | [macOS installation and usage](docs/install/macos.md) | In-app administrator-authorized daemon installation, repair, and removal |
 
 `msf update` and `msf uninstall` are only for Linux tarball/systemd installs. fnOS FPK, Unraid PLG, and Docker installs must be updated or removed through their platform manager.
 
@@ -58,8 +58,8 @@ https://github.com/scoltzero/msf/releases/tag/v0.4.0
 | fnOS x86 FPK | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_x86.fpk` |
 | fnOS ARM FPK | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_arm.fpk` |
 | Unraid PLG | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf.plg` |
-| macOS Universal 2 DMG (Beta) | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal.dmg` |
-| macOS Universal 2 ZIP (Beta) | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal.zip` |
+| macOS Universal 2 DMG (unsigned Beta) | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal-unsigned.dmg` |
+| macOS Universal 2 ZIP (unsigned Beta) | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal-unsigned.zip` |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - 支持 Mihomo 自定义配置、CodeMirror YAML 编辑器、组件更新检查、自动下载、更新通知和升级方式配置。
 - 支持 MosDNS、Mihomo、Zashboard 本地上传安装，网络困难时可用预下载核心离线安装。
 - Linux tarball/systemd、fnOS FPK、Unraid PLG 均支持 nftables 与 TUN；Docker `host-tun` / `macvlan-tun` 正式支持且仅允许 TUN。
-- macOS 15–26 提供 Beta 版原生 Universal 2 菜单栏 App、root LaunchDaemon 和 TUN-only 运行时，不提供系统代理模式。
+- macOS 15–26 提供未签名 Beta 版原生 Universal 2 菜单栏 App、root LaunchDaemon 和 TUN-only 运行时，不提供系统代理模式；首次打开需由用户手动允许。
 - Docker 部署必须把宿主机数据目录映射到容器 `/opt/msf`，默认示例使用 `./msf-data:/opt/msf`。
 
 ## 架构原理图
@@ -39,7 +39,7 @@
 | fnOS FPK | 支持 | [fnOS FPK 安装](docs/install/fnos-fpk.md) | fnOS / 飞牛应用中心或 FPK 包管理器 |
 | Unraid PLG | 稳定支持 | [Unraid PLG 安装](docs/install/unraid-plg.md) | Unraid 插件管理页面 |
 | Docker TUN host/macvlan | 支持（仅 TUN） | [Docker TUN 部署](docs/docker.md) | Docker / Compose / 容器管理器 |
-| macOS 15–26 菜单栏 App | Beta（仅 TUN） | [macOS 安装与使用](docs/install/macos.md) | App 内安装、修复和卸载后台 |
+| macOS 15–26 菜单栏 App | 未签名 Beta（仅 TUN） | [macOS 安装与使用](docs/install/macos.md) | App 内管理员授权安装、修复和卸载后台 |
 
 `msf update` 和 `msf uninstall` 只面向 Linux tarball/systemd 安装。fnOS FPK、Unraid PLG、Docker 请通过各自平台管理器更新或卸载，避免绕过包状态。
 
@@ -58,8 +58,8 @@ https://github.com/scoltzero/msf/releases/tag/v0.4.0
 | fnOS x86 FPK | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_x86.fpk` |
 | fnOS ARM FPK | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf_0.4.0_arm.fpk` |
 | Unraid PLG | `https://github.com/scoltzero/msf/releases/download/v0.4.0/msf.plg` |
-| macOS Universal 2 DMG（Beta） | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal.dmg` |
-| macOS Universal 2 ZIP（Beta） | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal.zip` |
+| macOS Universal 2 DMG（未签名 Beta） | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal-unsigned.dmg` |
+| macOS Universal 2 ZIP（未签名 Beta） | `https://github.com/scoltzero/msf/releases/download/v0.4.0/MSF-0.4.0-macos-universal-unsigned.zip` |
 
 ## 快速开始
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,18 +19,11 @@ git status --short
 
 最后一条必须无输出。发布版本以 `0.4.0` 这类不带 `v` 的值传给 Make，tag 使用 `v0.4.0`。
 
-## 2. macOS 发布凭据
+## 2. macOS 未签名 Beta 发布策略
 
-macOS 正式资产必须使用 Developer ID Application 签名并完成 Apple 公证。GitHub Actions 需要以下 Secrets：
+v0.4.0 的 macOS App 作为未签名 Beta 发布，不需要 Apple Developer、Developer ID 或公证 Secrets。Release 默认使用 legacy 管理员安装器，而不是 `SMAppService`；资产名称必须包含 `-unsigned`，安装文档和更新日志必须明确说明首次启动需要用户右键“打开”或在“隐私与安全”中手动允许。
 
-- `MACOS_CERTIFICATE_P12`：Developer ID Application `.p12` 的 Base64。
-- `MACOS_CERTIFICATE_PASSWORD`：`.p12` 密码。
-- `APPLE_TEAM_ID`：Apple Developer Team ID。
-- `APPLE_API_KEY_ID`：App Store Connect API Key ID。
-- `APPLE_API_ISSUER_ID`：App Store Connect Issuer ID。
-- `APPLE_API_PRIVATE_KEY`：API Key `.p8` 完整内容。
-
-未配置这些凭据时不要创建正式 tag。未签名 App 只能用于本地开发测试，不能上传到正式 Release。
+签名公证代码保留在非默认的 `MSF_SIGNED_RELEASE` 编译条件、`macos-app-build-signed` 和 `macos-release-assets-signed` 目标中。除非未来明确恢复 Developer ID 发布，否则 GitHub Actions 不得启用这些目标。
 
 ## 3. 创建不可变 tag
 
@@ -44,7 +37,7 @@ git push origin "v$VERSION"
 
 tag push 会触发两个工作流：
 
-- `Release assets`：分别构建 Linux/Unraid/fnOS 和签名公证的 macOS 资产，全部成功后一次性创建 GitHub Release。
+- `Release assets`：分别构建 Linux/Unraid/fnOS 和未签名 macOS Beta 资产，全部成功后一次性创建 GitHub Release。
 - `Docker GHCR`：构建并验证 `host-tun`、`macvlan-tun`，再推送 amd64/arm64 多架构镜像。
 
 两个工作流都会确认：
@@ -58,9 +51,9 @@ tag push 会触发两个工作流：
 macOS 工作流还会确认：
 
 - App 与 daemon 都包含 `arm64` 和 `x86_64`；
-- App 与 daemon 都使用 Developer ID Application 和 Hardened Runtime；
-- App、DMG 已通过 Apple Notarization 和 Staple；
-- Gatekeeper、Bundle 版本和 daemon 来源信息验证通过。
+- App 默认未链接 `ServiceManagement.framework`，Release 使用 legacy Installer；
+- Bundle 版本、daemon 来源信息、DMG/ZIP 内容和 SHA-256 验证通过；
+- 工作流不读取任何 Apple 签名或公证 Secret。
 
 ## 4. 发布资产
 
@@ -74,10 +67,10 @@ GitHub Release 应包含 20 个资产：
 macOS 资产名称：
 
 ```text
-MSF-0.4.0-macos-universal.dmg
-MSF-0.4.0-macos-universal.dmg.sha256
-MSF-0.4.0-macos-universal.zip
-MSF-0.4.0-macos-universal.zip.sha256
+MSF-0.4.0-macos-universal-unsigned.dmg
+MSF-0.4.0-macos-universal-unsigned.dmg.sha256
+MSF-0.4.0-macos-universal-unsigned.zip
+MSF-0.4.0-macos-universal-unsigned.zip.sha256
 ```
 
 fnOS 构建必须使用真正的 `fnpack`；下载失败会中止，绝不生成伪装成 `.fpk` 的 tar.gz fallback。
@@ -91,17 +84,14 @@ VERSION=0.4.0
 make release-assets VERSION="$VERSION" RELEASE_TAG="v$VERSION"
 ```
 
-已在 Keychain 中配置 Developer ID 与 Notary Profile 时，可构建 macOS：
+可直接构建未签名 macOS Beta，不需要 Apple 凭据：
 
 ```bash
 VERSION=0.4.0
 make macos-release-assets \
   VERSION="$VERSION" \
   RELEASE_TAG="v$VERSION" \
-  MACOS_BUILD_NUMBER=1 \
-  MACOS_DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-  MACOS_SIGNING_IDENTITY="$MACOS_SIGNING_IDENTITY" \
-  MACOS_NOTARY_PROFILE="$MACOS_NOTARY_PROFILE"
+  MACOS_BUILD_NUMBER=1
 ```
 
 ## 6. 发布后核验
@@ -114,12 +104,14 @@ docker buildx imagetools inspect "ghcr.io/scoltzero/msf:v$VERSION"
 
 确认 GitHub Release 包含全部 20 个安装资产和 SHA-256，GHCR 同时存在 `v0.4.0` 和 `latest`，且 revision 与 Release tag commit 相同。
 
-下载线上 DMG 后再执行一次：
+下载线上 macOS 资产后再校验摘要：
 
 ```bash
-xcrun stapler validate MSF-0.4.0-macos-universal.dmg
-spctl --assess --type open --context context:primary-signature --verbose=2 MSF-0.4.0-macos-universal.dmg
+shasum -a 256 -c MSF-0.4.0-macos-universal-unsigned.dmg.sha256
+shasum -a 256 -c MSF-0.4.0-macos-universal-unsigned.zip.sha256
 ```
+
+还应在一台未安装过 MSF 的 macOS 15 或更新系统上验证：右键打开 App、管理员授权安装后台、修复后台、卸载后台，以及卸载后 `/Library/Application Support/MSF` 数据保留行为。
 
 如需更新仓库根目录供 Unraid Community Apps 使用的 `msf.plg`，应直接下载本次 Release 中已经验证过的 `msf.plg`，逐字节替换并单独提交；不要重新打包生成另一个 txz 哈希。
 
@@ -135,6 +127,6 @@ spctl --assess --type open --context context:primary-signature --verbose=2 MSF-0
 
 ## 8. 失败处理
 
-- 任何测试、来源、dirty、签名、公证、摘要或黑盒检查失败，都不要创建 GitHub Release。
+- 任何测试、来源、dirty、Universal 2、legacy Installer、摘要或黑盒检查失败，都不要创建 GitHub Release。
 - 正式 tag 推送前必须完成候选构建；tag 一旦推送不再移动或覆盖。
 - 如果已推送 tag 的发布流程失败，修复后使用新的补丁版本，不替换旧 tag 或旧资产。

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -8,13 +8,13 @@ MSF v0.4.0 首次提供 macOS Beta 版菜单栏 App，最低支持 macOS 15，�
 
 从 [v0.4.0 GitHub Release](https://github.com/scoltzero/msf/releases/tag/v0.4.0) 下载：
 
-- `MSF-0.4.0-macos-universal.dmg`：推荐安装包。
-- `MSF-0.4.0-macos-universal.zip`：直接解压版本。
+- `MSF-0.4.0-macos-universal-unsigned.dmg`：推荐安装包。
+- `MSF-0.4.0-macos-universal-unsigned.zip`：直接解压版本。
 - 对应的 `.sha256`：用于校验下载文件。
 
-DMG、ZIP 与其中的 `MSF.app` 均使用 Apple Developer ID 签名并完成 Apple 公证。使用 DMG 时，将 `MSF.app` 拖入 `/Applications` 后再打开。
+首个 macOS Beta 未使用 Apple Developer ID 签名，也未提交 Apple 公证。使用 DMG 时，将 `MSF.app` 拖入 `/Applications`，然后在 Finder 中按住 Control 点击或右键 `MSF.app`，选择“打开”并再次确认。若系统仍阻止启动，请到“系统设置 → 隐私与安全”找到 MSF 的拦截提示并选择“仍要打开”。该确认只应对从本项目 GitHub Release 下载且 SHA-256 校验正确的文件执行。
 
-首次打开后进入“连接设置”，点击“安装后台”。Release App 使用 `SMAppService` 注册 root LaunchDaemon；如果 macOS 要求批准后台项目，请前往“系统设置 → 通用 → 登录项与扩展”允许 MSF，然后回到 App 刷新状态。
+首次打开后进入“连接设置”，点击“安装后台”并输入管理员密码。App 使用 legacy 管理员安装器，把 daemon 与 plist 安装到 `/Library/PrivilegedHelperTools` 和 `/Library/LaunchDaemons`，再由系统级 `launchd` 启动；不使用 `SMAppService`，也不需要在“登录项与扩展”中批准后台项目。
 
 ## 使用边界
 
@@ -29,7 +29,7 @@ DMG、ZIP 与其中的 `MSF.app` 均使用 Apple Developer ID 签名并完成 Ap
 ## 首次使用
 
 1. 将 `MSF.app` 放入 `/Applications` 并打开。
-2. 进入“连接设置”，点击“安装后台”，按系统提示批准 MSF 后台项目。
+2. 进入“连接设置”，点击“安装后台”，在系统授权窗口中输入管理员密码。
 3. 后台状态显示“运行中”后，点击“打开网页管理页”，完成六步初始化；macOS 页面只允许选择 TUN。
 4. 在初始化页下载 Mihomo、与现有配置兼容的 mssb MosDNS 和 Zashboard，填写订阅或手动节点。
 5. 回到“连接设置”，使用管理员账户绑定。密码仅用于这一次登录；App 创建的 `operate` Token 保存在 macOS Keychain。
@@ -63,7 +63,7 @@ networksetup -getdnsservers "Wi-Fi"
 sysctl net.inet.ip.forwarding
 ```
 
-启用后，`route -n get 28.0.0.1` 的 `interface` 应为某个 `utunN`。Release App 的 LaunchDaemon 输出可在 macOS“控制台”中按进程 `io.github.scoltzero.msf.daemon` 或 `msf` 检索。
+启用后，`route -n get 28.0.0.1` 的 `interface` 应为某个 `utunN`。LaunchDaemon 输出可在 macOS“控制台”中按进程 `io.github.scoltzero.msf.daemon` 或 `msf` 检索。
 
 系统数据位于 `/Library/Application Support/MSF`，网络恢复快照位于 `configs/network/darwin-state.json`。快照会记录原始 DNS 和 `net.inet.ip.forwarding`，恢复时不会假定其初始值一定为 `0`。
 
@@ -71,7 +71,7 @@ sysctl net.inet.ip.forwarding
 
 更新 App 时，先退出 MSF，将新版 `MSF.app` 替换到 `/Applications`，重新打开后在“连接设置”中执行后台修复，使 LaunchDaemon 使用新版内嵌后台。
 
-卸载前优先执行“完全停止服务…”，然后到“连接设置”点击“卸载后台”。后台和 LaunchDaemon 注册会被移除，`/Library/Application Support/MSF` 用户数据默认保留；确认不再需要时再手工清理该目录。
+卸载前优先执行“完全停止服务…”，然后到“连接设置”点击“卸载后台”。后台可执行文件和 LaunchDaemon plist 会从 `/Library` 移除，`/Library/Application Support/MSF` 用户数据默认保留；确认不再需要时再手工清理该目录。
 
 ## 源码构建
 
@@ -96,4 +96,4 @@ make macos-app-verify MACOS_CONFIGURATION=Debug
 make macos-app-verify MACOS_CONFIGURATION=Release
 ```
 
-Debug 构建产物为 `macos/MSFMenuBar/DerivedData/Build/Products/Debug/MSF.app`。执行 `make macos-app-open` 可重新构建并打开 Debug App。Debug App 使用管理员授权的 legacy LaunchDaemon 安装器，只用于本地开发测试。
+Debug 构建产物为 `macos/MSFMenuBar/DerivedData/Build/Products/Debug/MSF.app`。执行 `make macos-app-open` 可重新构建并打开 Debug App。当前 Debug、普通 Release 与 GitHub Release 均默认使用管理员授权的 legacy LaunchDaemon 安装器；保留的 `SMAppService` 实现只有在显式启用 `MSF_SIGNED_RELEASE` 编译条件时才会参与构建。

--- a/macos/MSFMenuBar/README.md
+++ b/macos/MSFMenuBar/README.md
@@ -22,7 +22,7 @@ v0.4.0 是 macOS App 的首个 Beta 版本。完整安装、LAN 路由要求、�
 - macOS 后台使用统一 `/api/v1/network/runtime/*` 状态机。
 - 客户端保留 `/api/v1/services/*` 与 `/api/v1/mihomo/traffic` 兼容逻辑，便于识别旧后台。
 - 旧后台无法安全实现“停止并让 LAN 直连保活”，因此该操作会保持禁用，不会静默退化为完全停机。
-- Debug App 使用 legacy LaunchDaemon 安装器；签名 Release App 使用 `SMAppService`。
+- Debug、普通 Release 与当前 GitHub Release 均使用管理员授权的 legacy LaunchDaemon 安装器。`SMAppService` 实现保留在 `MSF_SIGNED_RELEASE` 编译条件后，默认不参与构建。
 
 ## 本地开发
 
@@ -47,18 +47,17 @@ make macos-app-build XCODE_DEVELOPER_DIR=/Applications/Xcode.app/Contents/Develo
 
 默认后台地址为 `http://127.0.0.1:7777`。首次启动后进入“连接设置”，使用管理员账户配对或粘贴 `operate` Token。
 
-## 正式发布
+## GitHub Release
 
-签名发布需要 Developer ID Application、Apple Notary API 凭据和干净且已打 tag 的源码：
+当前 v0.4.0 macOS Beta 以未签名方式发布，需要干净且已打 tag 的源码，不需要 Apple Developer 凭据：
 
 ```bash
 make macos-release-assets \
   VERSION=0.4.0 \
   RELEASE_TAG=v0.4.0 \
-  MACOS_BUILD_NUMBER=1 \
-  MACOS_DEVELOPMENT_TEAM=<TEAM_ID> \
-  MACOS_SIGNING_IDENTITY=<DEVELOPER_ID_IDENTITY> \
-  MACOS_NOTARY_PROFILE=<NOTARY_PROFILE>
+  MACOS_BUILD_NUMBER=1
 ```
 
-该目标会构建、签名并公证 Universal 2 App，随后在 `dist/macos/` 生成 DMG、ZIP 和 SHA-256。
+该目标会构建 legacy Installer 版 Universal 2 App，随后在 `dist/macos/` 生成名称包含 `-unsigned` 的 DMG、ZIP 和 SHA-256。用户首次启动需要在 Finder 中右键“打开”或到“隐私与安全”中手动允许。
+
+原 Developer ID/公证路径仍保留为非默认的 `macos-release-assets-signed` 目标，只有显式提供签名和公证参数时才会启用 `MSF_SIGNED_RELEASE` 与 `SMAppService`。

--- a/macos/MSFMenuBar/Scripts/package-release-signed.sh
+++ b/macos/MSFMenuBar/Scripts/package-release-signed.sh
@@ -5,51 +5,44 @@ version="${1:?version is required}"
 release_tag="${2:?release tag is required}"
 expected_commit="${3:?expected commit is required}"
 output_dir="${4:?output directory is required}"
+sign_identity="${MACOS_SIGNING_IDENTITY:?MACOS_SIGNING_IDENTITY is required}"
+notary_profile="${MACOS_NOTARY_PROFILE:?MACOS_NOTARY_PROFILE is required}"
 
 project_root="$(cd "$(dirname "$0")/.." && /bin/pwd)"
-repo_root="$(cd "$project_root/../.." && /bin/pwd)"
 app="$project_root/DerivedData/Build/Products/Release/MSF.app"
-asset_prefix="MSF-$version-macos-universal-unsigned"
+asset_prefix="MSF-$version-macos-universal"
 dmg="$output_dir/$asset_prefix.dmg"
 zip="$output_dir/$asset_prefix.zip"
 tmp="$(/usr/bin/mktemp -d)"
-mounted=0
-mount_point="$tmp/dmg-mount"
 
 cleanup() {
-  if [[ "$mounted" == "1" ]]; then
-    /usr/bin/hdiutil detach "$mount_point" -quiet >/dev/null 2>&1 || true
-  fi
   /bin/rm -rf "$tmp"
 }
 trap cleanup EXIT INT TERM
 
 fail() {
-  echo "package-release: $*" >&2
+  echo "package-release-signed: $*" >&2
   exit 1
-}
-
-verify_app() {
-  local app_path="$1"
-  MSF_APP_PATH="$app_path" \
-  MSF_EXPECTED_VERSION="$version" \
-  MSF_EXPECTED_COMMIT="$expected_commit" \
-  MSF_EXPECTED_TAG="$release_tag" \
-  MSF_REQUIRE_LEGACY_ONLY=1 \
-    "$project_root/Scripts/verify-app.sh" Release
 }
 
 [[ "$release_tag" == "v$version" ]] || fail "$release_tag does not match version $version"
 [[ -d "$app" ]] || fail "Release app not found: $app"
 
-verify_app "$app"
-
-signature_info="$(/usr/bin/codesign -dvvv "$app" 2>&1 || true)"
-[[ "$signature_info" != *"Authority=Developer ID Application:"* ]] \
-  || fail "unsigned beta unexpectedly contains a Developer ID signature"
+MSF_EXPECTED_VERSION="$version" \
+MSF_EXPECTED_COMMIT="$expected_commit" \
+MSF_EXPECTED_TAG="$release_tag" \
+MSF_REQUIRE_DEVELOPER_ID=1 \
+  "$project_root/Scripts/verify-app.sh" Release
 
 /bin/mkdir -p "$output_dir"
 /bin/rm -f "$dmg" "$dmg.sha256" "$zip" "$zip.sha256"
+
+notary_zip="$tmp/MSF-notary.zip"
+/usr/bin/ditto -c -k --sequesterRsrc --keepParent "$app" "$notary_zip"
+/usr/bin/xcrun notarytool submit "$notary_zip" --keychain-profile "$notary_profile" --wait
+/usr/bin/xcrun stapler staple "$app"
+/usr/bin/xcrun stapler validate "$app"
+/usr/sbin/spctl --assess --type execute --verbose=2 "$app"
 
 /usr/bin/ditto -c -k --sequesterRsrc --keepParent "$app" "$zip"
 
@@ -57,26 +50,23 @@ dmg_root="$tmp/dmg-root"
 /bin/mkdir -p "$dmg_root"
 /usr/bin/ditto "$app" "$dmg_root/MSF.app"
 /bin/ln -s /Applications "$dmg_root/Applications"
-/bin/cp "$repo_root/docs/install/macos.md" "$dmg_root/安装说明.md"
 /usr/bin/hdiutil create \
-  -volname "MSF Unsigned Beta" \
+  -volname "MSF" \
   -srcfolder "$dmg_root" \
   -ov \
   -format UDZO \
   "$dmg"
-/usr/bin/hdiutil verify "$dmg" >/dev/null
+/usr/bin/codesign --force --timestamp --sign "$sign_identity" "$dmg"
+/usr/bin/xcrun notarytool submit "$dmg" --keychain-profile "$notary_profile" --wait
+/usr/bin/xcrun stapler staple "$dmg"
+/usr/bin/xcrun stapler validate "$dmg"
+/usr/sbin/spctl --assess --type open --context context:primary-signature --verbose=2 "$dmg"
 
 zip_check="$tmp/zip-check"
 /bin/mkdir -p "$zip_check"
 /usr/bin/ditto -x -k "$zip" "$zip_check"
-verify_app "$zip_check/MSF.app"
-
-/bin/mkdir -p "$mount_point"
-/usr/bin/hdiutil attach "$dmg" -readonly -nobrowse -mountpoint "$mount_point" -quiet
-mounted=1
-verify_app "$mount_point/MSF.app"
-/usr/bin/hdiutil detach "$mount_point" -quiet
-mounted=0
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$zip_check/MSF.app"
+/usr/bin/xcrun stapler validate "$zip_check/MSF.app"
 
 (
   cd "$output_dir"
@@ -84,5 +74,5 @@ mounted=0
   /usr/bin/shasum -a 256 "$(basename "$zip")" > "$(basename "$zip").sha256"
 )
 
-echo "packaged-unsigned:$dmg"
-echo "packaged-unsigned:$zip"
+echo "packaged-signed:$dmg"
+echo "packaged-signed:$zip"

--- a/macos/MSFMenuBar/Scripts/verify-app.sh
+++ b/macos/MSFMenuBar/Scripts/verify-app.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 configuration="${1:-Debug}"
 project_root="$(cd "$(dirname "$0")/.." && /bin/pwd)"
-app="$project_root/DerivedData/Build/Products/$configuration/MSF.app"
+app="${MSF_APP_PATH:-$project_root/DerivedData/Build/Products/$configuration/MSF.app}"
 main_binary="$app/Contents/MacOS/MSF"
 helper_name="io.github.scoltzero.msf.daemon"
 helper="$app/Contents/Library/HelperTools/$helper_name"
@@ -14,6 +14,7 @@ expected_version="${MSF_EXPECTED_VERSION:-}"
 expected_commit="${MSF_EXPECTED_COMMIT:-}"
 expected_tag="${MSF_EXPECTED_TAG:-}"
 require_developer_id="${MSF_REQUIRE_DEVELOPER_ID:-0}"
+require_legacy_only="${MSF_REQUIRE_LEGACY_ONLY:-0}"
 
 fail() {
   echo "verify-app: $*" >&2
@@ -55,6 +56,12 @@ fi
 /bin/zsh -n "$project_root/Resources/msf-daemon-installer.sh"
 /bin/zsh -n "$installer"
 /usr/bin/codesign --verify --strict "$helper"
+
+if [[ "$require_legacy_only" == "1" ]]; then
+  if /usr/bin/otool -L "$main_binary" | /usr/bin/grep -q '/ServiceManagement.framework/'; then
+    fail "unsigned beta must not link ServiceManagement or use SMAppService"
+  fi
+fi
 
 provenance="$("$helper" version --json)" || fail "cannot read embedded daemon provenance"
 /usr/bin/python3 - "$provenance" "$expected_version" "$expected_commit" "$expected_tag" <<'PY' \

--- a/macos/MSFMenuBar/Sources/MSFMenuBarApp/DaemonServiceModel.swift
+++ b/macos/MSFMenuBar/Sources/MSFMenuBarApp/DaemonServiceModel.swift
@@ -1,5 +1,8 @@
 import Foundation
+
+#if MSF_SIGNED_RELEASE
 @preconcurrency import ServiceManagement
+#endif
 
 @MainActor
 final class DaemonServiceModel: ObservableObject {
@@ -19,7 +22,10 @@ final class DaemonServiceModel: ObservableObject {
   private static let label = "io.github.scoltzero.msf.daemon"
   private static let plistName = label + ".plist"
   private static let helperPath = "/Library/PrivilegedHelperTools/" + label
+
+  #if MSF_SIGNED_RELEASE
   private let service = SMAppService.daemon(plistName: plistName)
+  #endif
 
   var title: String {
     switch state {
@@ -54,7 +60,7 @@ final class DaemonServiceModel: ObservableObject {
   }
 
   var canInstall: Bool {
-    !isBusy && state != .running
+    !isBusy
   }
 
   var canUninstall: Bool {
@@ -79,20 +85,25 @@ final class DaemonServiceModel: ObservableObject {
       detail = "后台文件已安装，但端口 7777 尚未就绪"
       return
     }
-    switch service.status {
-    case .enabled:
-      state = .installed
-      detail = "系统服务已启用，正在等待后台启动"
-    case .requiresApproval:
-      state = .approvalRequired
-      detail = "请在“系统设置 → 通用 → 登录项与扩展”中允许 MSF"
-    case .notRegistered, .notFound:
+    #if MSF_SIGNED_RELEASE
+      switch service.status {
+      case .enabled:
+        state = .installed
+        detail = "系统服务已启用，正在等待后台启动"
+      case .requiresApproval:
+        state = .approvalRequired
+        detail = "请在“系统设置 → 通用 → 登录项与扩展”中允许 MSF"
+      case .notRegistered, .notFound:
+        state = .notInstalled
+        detail = "安装后由 root LaunchDaemon 管理 TUN、DNS 和路由"
+      @unknown default:
+        state = .notInstalled
+        detail = "尚未安装 MSF 系统后台"
+      }
+    #else
       state = .notInstalled
       detail = "安装后由 root LaunchDaemon 管理 TUN、DNS 和路由"
-    @unknown default:
-      state = .notInstalled
-      detail = "尚未安装 MSF 系统后台"
-    }
+    #endif
   }
 
   func install() {
@@ -102,10 +113,7 @@ final class DaemonServiceModel: ObservableObject {
     Task {
       defer { isBusy = false }
       do {
-        #if DEBUG
-          let output = try await Self.runLegacyInstaller(action: "install")
-          detail = output.isEmpty ? "后台安装完成，正在等待启动" : output
-        #else
+        #if MSF_SIGNED_RELEASE
           if service.status == .enabled {
             try await service.unregister()
           }
@@ -113,6 +121,9 @@ final class DaemonServiceModel: ObservableObject {
           if service.status == .requiresApproval {
             SMAppService.openSystemSettingsLoginItems()
           }
+        #else
+          let output = try await Self.runLegacyInstaller(action: "install")
+          detail = output.isEmpty ? "后台安装完成，正在等待启动" : output
         #endif
         await waitForBackend()
         await refresh()
@@ -130,14 +141,14 @@ final class DaemonServiceModel: ObservableObject {
     Task {
       defer { isBusy = false }
       do {
-        #if DEBUG
-          let output = try await Self.runLegacyInstaller(action: "uninstall")
-          detail = output.isEmpty ? "后台已卸载，配置数据已保留" : output
-        #else
+        #if MSF_SIGNED_RELEASE
           if service.status != .notRegistered && service.status != .notFound {
             try await service.unregister()
           }
           detail = "后台已取消注册，配置数据已保留"
+        #else
+          let output = try await Self.runLegacyInstaller(action: "uninstall")
+          detail = output.isEmpty ? "后台已卸载，配置数据已保留" : output
         #endif
         try? await Task.sleep(for: .milliseconds(500))
         await refresh()
@@ -149,7 +160,9 @@ final class DaemonServiceModel: ObservableObject {
   }
 
   func openApprovalSettings() {
-    SMAppService.openSystemSettingsLoginItems()
+    #if MSF_SIGNED_RELEASE
+      SMAppService.openSystemSettingsLoginItems()
+    #endif
   }
 
   private func waitForBackend() async {


### PR DESCRIPTION
## Summary
- make Legacy LaunchDaemon installation the default for Debug and Release
- keep SMAppService behind the optional MSF_SIGNED_RELEASE compile condition
- publish clearly named unsigned DMG/ZIP assets without Apple signing secrets
- document first-launch approval and administrator installation

## Validation
- go test ./...
- npm --prefix web run check
- 13 Swift tests
- Debug/Release Universal 2 build and legacy-only verification
- signed-path compile check
- unsigned DMG/ZIP create, mount, extract, provenance and SHA-256 verification
- actionlint and zsh syntax checks

No LaunchDaemon was installed and no DNS, route, or TUN state was changed.